### PR TITLE
Fix attribution on N64 driver

### DIFF
--- a/libmikmod/drivers/drv_n64.c
+++ b/libmikmod/drivers/drv_n64.c
@@ -21,7 +21,7 @@
 /*==============================================================================
 
   Driver for output on n64 platform
-  Originally from http://www.n64dev.net/ by ???
+  Originally from https://dragonminded.com/n64dev/ by DragonMinded
 
   Altered and updated to mikmod 3.3.11 by Victor Vieux <github@vrgl117.games>
 


### PR DESCRIPTION
Stumbled on this, I wrote the N64 code way back in 2009 and I guess it got uploaded to mediafire and put on n64dev.net?