### PR TITLE
Fix handling of .FAR pattern break byte.

### DIFF
--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -258,7 +258,8 @@ static BOOL FAR_Load(BOOL curious)
 
 			crow = pat;
 			/* file often allocates 64 rows even if there are less in pattern */
-			if (mh2->patsiz[t]<2+(rows*16*4)) {
+			/* Also, don't allow more than 256 rows. */
+			if (mh2->patsiz[t]<2+(rows*16*4) || rows>256) {
 				_mm_errno = MMERR_LOADING_PATTERN;
 				return 0;
 			}

--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -245,12 +245,14 @@ static BOOL FAR_Load(BOOL curious)
 	if(!AllocPatterns()) return 0;
 
 	for(t=0;t<of.numpat;t++) {
-		UBYTE rows=0;
+		UWORD rows=0;
 		UBYTE tempo;
 
 		memset(pat,0,256*16*4*sizeof(FARNOTE));
 		if(mh2->patsiz[t]) {
-			rows  = _mm_read_UBYTE(modreader);
+			/* Break position byte is always 1 less than the final row index,
+			   i.e. it is 2 less than the total row count. */
+			rows  = _mm_read_UBYTE(modreader) + 2;
 			tempo = _mm_read_UBYTE(modreader);
 			(void)tempo; /* unused */
 

--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -93,6 +93,7 @@ static	FARHEADER2 *mh2 = NULL;
 static	FARNOTE *pat = NULL;
 
 static	const unsigned char FARSIG[4+3]={'F','A','R',0xfe,13,10,26};
+static  const UWORD FAR_MAXPATSIZE=(256*16*4)+2;
 
 /*========== Loader code */
 
@@ -259,7 +260,7 @@ static BOOL FAR_Load(BOOL curious)
 			crow = pat;
 			/* file often allocates 64 rows even if there are less in pattern */
 			/* Also, don't allow more than 256 rows. */
-			if (mh2->patsiz[t]<2+(rows*16*4) || rows>256) {
+			if (mh2->patsiz[t]<2+(rows*16*4) || rows>256 || mh2->patsiz[t]>FAR_MAXPATSIZE) {
 				_mm_errno = MMERR_LOADING_PATTERN;
 				return 0;
 			}


### PR DESCRIPTION
Despite the confusing documentation for the .FAR format, the first byte of each pattern in a .FAR file is not the pattern length in bytes but instead represents the index of the final row of the pattern, minus 1. Farandole Composer uses the value of this byte plus 2 to determine the final length of the pattern. This patch changes the .FAR loader to add 2 to this byte when deriving the row count.

This fixes #5.