### PR TITLE
Add support for Mod's Grave .WOW files.

### DIFF
--- a/libmikmod/loaders/load_mod.c
+++ b/libmikmod/loaders/load_mod.c
@@ -88,6 +88,7 @@ static CHAR oktalyser[] = "Oktalyser";
 static CHAR oktalyzer[] = "Oktalyzer";
 static CHAR taketracker[] = "TakeTracker";
 static CHAR orpheus[] = "Imago Orpheus (MOD format)";
+static CHAR modsgrave[] = "Mod's Grave";
 
 static MODULEHEADER *mh = NULL;
 static MODNOTE *patbuf = NULL;
@@ -368,6 +369,15 @@ static BOOL MOD_Load(BOOL curious)
 	SAMPLE *q;
 	MSAMPINFO *s;
 	CHAR *descr;
+	BOOL maybewow = 1;
+	ULONG samplelength = 0;
+	ULONG filelength;
+	ULONG pos;
+
+	pos = _mm_ftell(modreader);
+	_mm_fseek(modreader, 0, SEEK_END);
+	filelength = _mm_ftell(modreader);
+	_mm_fseek(modreader, pos, SEEK_SET);
 
 	/* try to read module header */
 	_mm_read_string((CHAR *)mh->songname, 20, modreader);
@@ -382,6 +392,11 @@ static BOOL MOD_Load(BOOL curious)
 		s->volume = _mm_read_UBYTE(modreader);
 		s->reppos = _mm_read_M_UWORD(modreader);
 		s->replen = _mm_read_M_UWORD(modreader);
+		/* Mod's Grave .WOW files are converted from .669 and thus
+		   do not have sample finetune or volume. */
+		samplelength += (ULONG)s->length << 1;
+		if (s->length && (s->finetune != 0x00 || s->volume != 0x40))
+			maybewow = 0;
 	}
 
 	mh->songlength = _mm_read_UBYTE(modreader);
@@ -393,6 +408,10 @@ static BOOL MOD_Load(BOOL curious)
 	mh->magic1 = _mm_read_UBYTE(modreader);
 	_mm_read_UBYTES(mh->positions, 128, modreader);
 	_mm_read_UBYTES(mh->magic2, 4, modreader);
+
+	/* Mod's Grave .WOW files always use 0x00 for the "restart" byte. */
+	if (mh->magic1 != 0x00)
+		maybewow = 0;
 
 	if (_mm_eof(modreader)) {
 		_mm_errno = MMERR_LOADING_HEADER;
@@ -443,6 +462,24 @@ static BOOL MOD_Load(BOOL curious)
 				of.numpos = t + 1;
 		}
 	of.numpat++;
+
+	/* Mod's Grave .WOW files have an M.K. signature but they're actually 8 channel.
+	   The only way to distinguish them from a 4-channel M.K. file is to check the
+	   length of the .MOD against the expected length of a .WOW file with the same
+	   number of patterns as this file. To make things harder, Mod's Grave occasionally
+	   adds an extra byte to .WOW files and sometimes .MOD authors pad their files.
+	   Prior checks for WOW behavior should help eliminate false positives here.
+
+	   Also note the length check relies on counting samples with a length word=1 to work. */
+	if (modtype == 0 && maybewow == 1) {
+		ULONG wowlength = MODULEHEADERSIZE + 4 + samplelength + of.numpat * (64 * 4 * 8);
+		if ((filelength & ~1) == wowlength) {
+			modtype = 1;
+			descr = modsgrave;
+			of.numchn = 8;
+		}
+	}
+
 	of.numtrk = of.numpat * of.numchn;
 
 	if (!AllocPositions(of.numpos))


### PR DESCRIPTION
Mod's Grave .WOW files are an unusual .MOD variant with a M.K. signature but 8 channels. They are converted from .669 files using a converter packaged with the Mod's Grave player for DOS. By calculating the expected size of a .WOW file, it is possible to detect these files.

This patch also includes some extra checks to avoid false positives in .WOW detection when loading certain mods (example: ponylips.mod).

I've tested this patch a bit and I'm fairly confident it works correctly now. Fixes #7.