### PR TITLE
Add check for M&K! and CD61 signatures and fix 'Octalyser' spelling.

### DIFF
--- a/libmikmod/loaders/load_mod.c
+++ b/libmikmod/loaders/load_mod.c
@@ -84,7 +84,7 @@ typedef struct MODNOTE {
 static CHAR protracker[] = "Protracker";
 static CHAR startrekker[] = "Startrekker";
 static CHAR fasttracker[] = "Fasttracker";
-static CHAR oktalyser[] = "Oktalyser";
+static CHAR octalyser[] = "Octalyser";
 static CHAR oktalyzer[] = "Oktalyzer";
 static CHAR taketracker[] = "TakeTracker";
 static CHAR orpheus[] = "Imago Orpheus (MOD format)";
@@ -102,7 +102,7 @@ static BOOL MOD_CheckType(UBYTE *id, UBYTE *numchn, CHAR **descr)
 	modtype = trekker = 0;
 
 	/* Protracker and variants */
-	if ((!memcmp(id, "M.K.", 4)) || (!memcmp(id, "M!K!", 4))) {
+	if ((!memcmp(id, "M.K.", 4)) || (!memcmp(id, "M!K!", 4)) || (!memcmp(id, "M&K!", 4))) {
 		*descr = protracker;
 		modtype = 0;
 		*numchn = 4;
@@ -132,11 +132,11 @@ static BOOL MOD_CheckType(UBYTE *id, UBYTE *numchn, CHAR **descr)
 		return 1;
 	}
 
-	/* Oktalyser (Atari) */
-	if (!memcmp(id, "CD81", 4)) {
-		*descr = oktalyser;
+	/* Octalyser (Atari) */
+	if (!memcmp(id, "CD81", 4) || !memcmp(id, "CD61", 4)) {
+		*descr = octalyser;
 		modtype = 1;
-		*numchn = 8;
+		*numchn = id[2] - '0';
 		return 1;
 	}
 


### PR DESCRIPTION
This patch adds checks for a couple of less common .MOD signatures I found were missing during my .WOW testing.

* `M&K!` is a signature associated with a hacked version of NoiseTracker created by Mahoney for His Master's Noise. These tracks are not guaranteed to use His Master's Noise extensions (numerous tracks from that disk appear not to) or to even be from His Master's Noise. Attached ZIP has three of the latter, though the vast majority of `M&K!` signatures do appear to be from this disk.
[m_and_k!.zip](https://github.com/sezero/mikmod/files/5398189/m_and_k.zip)

* `CD61` is a lesser-used Octalyser signature for 6 channel mods (as opposed to the 8 channel `CD81`). Attached ZIP contains the 3 `CD61` .MODs I could find on ModLand.
[CD61.zip](https://github.com/sezero/mikmod/files/5398190/CD61.zip)