### PR TITLE
Fix note tuning for .669 modules.

### DIFF
--- a/libmikmod/loaders/load_669.c
+++ b/libmikmod/loaders/load_669.c
@@ -329,7 +329,7 @@ static BOOL S69_Load(BOOL curious)
 
 		current->samplename=DupStr(sample.filename,13,1);
 		current->seekpos=0;
-		current->speed=0;
+		current->speed=128; /* Used as finetune when UF_XMPERIODS is enabled; 128 is centered. */
 		current->length=sample.length;
 		current->loopstart=sample.loopbeg;
 		current->loopend=sample.loopend;


### PR DESCRIPTION
Support for Composer/Unis 669 modules is implemented to use the XM tuning system but the field used for the finetune value when XM tuning is enabled isn't properly initialized. This makes every .669 module play a whole tone in pitch lower than it ought to.

Sample files (every single 669 module is affected so these are just two where it's very obvious).
* [crystals.669.zip](https://github.com/sezero/mikmod/files/5412952/crystals.669.zip)
* [remix-1.2.669.zip](https://github.com/sezero/mikmod/files/5412953/remix-1.2.669.zip)

