### PR TITLE
Fix XM fine volume slide effects.

### DIFF
--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1475,11 +1475,11 @@ static int DoXMEffectEA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	UBYTE dat;
 
 	dat=UniGetByte();
-	if (!tick)
+	if (!tick) {
 		if (dat) a->fslideupspd=dat;
-	a->tmpvolume+=a->fslideupspd;
-	if (a->tmpvolume>64) a->tmpvolume=64;
-
+		a->tmpvolume+=a->fslideupspd;
+		if (a->tmpvolume>64) a->tmpvolume=64;
+	}
 	return 0;
 }
 
@@ -1488,11 +1488,11 @@ static int DoXMEffectEB(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	UBYTE dat;
 
 	dat=UniGetByte();
-	if (!tick)
+	if (!tick) {
 		if (dat) a->fslidednspd=dat;
-	a->tmpvolume-=a->fslidednspd;
-	if (a->tmpvolume<0) a->tmpvolume=0;
-
+		a->tmpvolume-=a->fslidednspd;
+		if (a->tmpvolume<0) a->tmpvolume=0;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The XM fine volume slide effects are supposed to only change the note volume on the first tick of each row, but instead they were changing it every tick.

Example file: fine volslides down 64 times then up 64 times. The notes should only barely reach volume 0 at the end of the first pattern, but prior to this fix, the slides would reach 0 volume after only ~11 rows.
[FineVol.xm.zip](https://github.com/sezero/mikmod/files/5449924/FineVol.xm.zip)
