### PR TITLE
Implement missing OctaMED effects and fix several other MED effects.

### DIFF
--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -338,6 +338,17 @@ enum {
  /* Oktalyzer effects */
     UNI_OKTARP,     /* arpeggio */
 
+ /* Last effect supported by old modules in the UNI format. */
+    UNI_FORMAT_LAST,
+
+ /* OctaMED effects. */
+    UNI_MEDEFFECT_VIB, /* MED vibrato */
+    UNI_MEDEFFECT_FD,  /* set pitch */
+    UNI_MEDEFFECT_16,  /* loop */
+    UNI_MEDEFFECT_18,  /* stop note */
+    UNI_MEDEFFECT_1E,  /* pattern delay */
+    UNI_MEDEFFECT_1F,  /* note delay and retrigger */
+
     UNI_LAST
 };
 

--- a/libmikmod/loaders/load_uni.c
+++ b/libmikmod/loaders/load_uni.c
@@ -201,7 +201,7 @@ static UBYTE* readtrack(void)
 					opcode++;
 			}
 
-			if((!opcode)||(opcode>=UNI_LAST)) {
+			if((!opcode)||(opcode>=UNI_FORMAT_LAST)) {
 				MikMod_free(t);
 				return NULL;
 			}

--- a/libmikmod/playercode/munitrk.c
+++ b/libmikmod/playercode/munitrk.c
@@ -100,6 +100,13 @@ const UWORD unioperands[UNI_LAST] = {
 	0, /* UNI_MEDEFFECTF2 */
 	0, /* UNI_MEDEFFECTF3 */
 	2, /* UNI_OKTARP */
+	0, /* not used */
+	2, /* UNI_MEDEFFECT_VIB */
+	0, /* UNI_MEDEFFECT_FD */
+	1, /* UNI_MEDEFFECT_16 */
+	1, /* UNI_MEDEFFECT_18 */
+	1, /* UNI_MEDEFFECT_1E */
+	1, /* UNI_MEDEFFECT_1F */
 };
 
 /* Sparse description of the internal module format


### PR DESCRIPTION
Squashed version of https://github.com/sezero/mikmod/compare/master...AliceLR:fix-med-effects. Fixes #19. The MED portions of this patch I think have been fairly well tested. The only non-MED things this touches are the UNI loader (should be exactly equivalent to what it was doing before) and separating `DoLoop` from `DoEEffects` (same). This should probably still be carefully reviewed.

I don't know precisely how many MED modules this patch fixes or at least improves but it's in the several hundred to maybe >1000 range.

Implements the following OctaMED effects:

* `5xx`: continue portamento + volslide (maps to MOD `5xx`) (MMD1).
* `6xx`: continue vibrato + volslide (maps to MOD `6xx`).
* `7xx`: tremolo (maps to MOD `7xx`).
* `FF8`: turn low-pass filter off (maps to MOD `E01`; does nothing).
* `FF9`: turn low-pass filter on (maps to MOD `E00`; does nothing).
* `FFD`: set pitch (without retriggering note) (new UNI effect).
* `11xx`: fine portamento up (maps to XM `E1x`, ignores `1100`).
* `12xx`: fine portamento down (maps to XM `E2x`, ignores `1200`).
* `14xx`: Protracker vibrato (new UNI effect shared with 4xx and old `5xx`, see fixes section). This effect has .MOD-compatible depth but the speed is still about 2-3 times as fast.
* `15xx`: set instrument finetune (maps to MOD `E5x`).
* `16xx`: loop (new UNI effect due to extended range and quirks).
* `18xx`: cut note (new UNI effect due to extended range).
* `19xx`: sample offset (maps to MOD `9xx`).
* `1Axx`: fine volslide up (maps to XM `EAx`, ignores `1A00`).
* `1Bxx`: fine volslide down (maps to XM `EBx`, ignores `1B00`).
* `1Dxx`: pattern break (maps to MOD `Dxx`).
* `1Exx`: pattern delay (new UNI effect due to extended range).
* `1Fxx`: combined note delay/retrigger (new UNI effect).

Fixes for existing OctaMED effects:

* `1xx`: portamento up. MikMod now ignores `100`.
* `2xx`: portamento down. MikMod now ignores `200`.
* `4xx`: vibrato. This effect has twice the depth and roughly 2-3 times the speed of MOD vibrato. Previously it was being treated as equivalent to MOD vibrato.
* `5xx`: old vibrato. This effect is only used by MMD0s and was replaced by the OctaMED 3/MMD1 Portamento+Volslide effect. The old implementation was treating it as having both a depth and a speed nibble, but the entire param is depth.
* `9xx`: speed. Added a check to ignore `900` usage for now.
* `Axx`: volslide. MikMod now prioritizes slides up when both nibbles are set.
* `Dxx`: volslide. See above.
* `FF1`: trigger note twice. This effect retriggers a note exactly one time on tick 3 and does nothing else. Previously this was being mapped to `E9x` and was scaled to the current speed. Works on lines without a note.
* `FF2`: delay note. This effect delays a note exactly 3 ticks. Previously this was scaling the delay to the current speed.
* `FF3`: trigger note three times. This effect is similar to `E92` but uses its own retrigger implementation. Previously this was using `E9x` and was scaled to the current speed. Works on lines without a note.

edit: forgot to mention one minor unrelated fix: instrument default volume is no longer ignored.