### PR TITLE
Merge vibrato tables/math, fix tremolo ramp down, fix IT vibrato.

### DIFF
--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -341,6 +341,11 @@ enum {
  /* Last effect supported by old modules in the UNI format. */
     UNI_FORMAT_LAST,
 
+ /* Scream Tracker effects */
+    UNI_S3MEFFECTH,    /* vibrato */
+ /* Impulse Tracker effects */
+    UNI_ITEFFECTH_OLD, /* vibrato (old) */
+    UNI_ITEFFECTU_OLD, /* fine vibrato (old) */
  /* OctaMED effects. */
     UNI_MEDEFFECT_VIB, /* MED vibrato */
     UNI_MEDEFFECT_FD,  /* set pitch */

--- a/libmikmod/playercode/mlutil.c
+++ b/libmikmod/playercode/mlutil.c
@@ -182,9 +182,12 @@ void S3MIT_ProcessCmd(UBYTE cmd, UBYTE inf, unsigned int flags)
 					UniEffect(UNI_ITEFFECTG,inf);
 				break;
 			case 8: /* Hxy vibrato */
-				if (flags & S3MIT_OLDSTYLE)
-					UniPTEffect(0x4,inf);
-				else
+				if (flags & S3MIT_OLDSTYLE) {
+					if (flags & S3MIT_IT)
+						UniEffect(UNI_ITEFFECTH_OLD,inf);
+					else
+						UniEffect(UNI_S3MEFFECTH,inf);
+				} else
 					UniEffect(UNI_ITEFFECTH,inf);
 				break;
 			case 9: /* Ixy tremor, ontime x, offtime y */
@@ -197,9 +200,12 @@ void S3MIT_ProcessCmd(UBYTE cmd, UBYTE inf, unsigned int flags)
 				UniPTEffect(0x0,inf);
 				break;
 			case 0xb: /* Kxy Dual command H00 & Dxy */
-				if (flags & S3MIT_OLDSTYLE)
-					UniPTEffect(0x4,0);
-				else
+				if (flags & S3MIT_OLDSTYLE) {
+					if (flags & S3MIT_IT)
+						UniEffect(UNI_ITEFFECTH_OLD,0);
+					else
+						UniEffect(UNI_S3MEFFECTH,0);
+				} else
 					UniEffect(UNI_ITEFFECTH,0);
 				UniEffect(UNI_S3MEFFECTD,inf);
 				break;
@@ -259,9 +265,12 @@ void S3MIT_ProcessCmd(UBYTE cmd, UBYTE inf, unsigned int flags)
 				}
 				break;
 			case 0x15: /* Uxy Fine Vibrato speed x, depth y */
-				if(flags & S3MIT_OLDSTYLE)
-					UniEffect(UNI_S3MEFFECTU,inf);
-				else
+				if(flags & S3MIT_OLDSTYLE) {
+					if (flags & S3MIT_IT)
+						UniEffect(UNI_ITEFFECTU_OLD,inf);
+					else
+						UniEffect(UNI_S3MEFFECTU,inf);
+				} else
 					UniEffect(UNI_ITEFFECTU,inf);
 				break;
 			case 0x16: /* Vxx Set Global Volume */

--- a/libmikmod/playercode/munitrk.c
+++ b/libmikmod/playercode/munitrk.c
@@ -101,6 +101,9 @@ const UWORD unioperands[UNI_LAST] = {
 	0, /* UNI_MEDEFFECTF3 */
 	2, /* UNI_OKTARP */
 	0, /* not used */
+	1, /* UNI_S3MEFFECTH */
+	1, /* UNI_ITEFFECTH_OLD */
+	1, /* UNI_ITEFFECTU_OLD */
 	2, /* UNI_MEDEFFECT_VIB */
 	0, /* UNI_MEDEFFECT_FD */
 	1, /* UNI_MEDEFFECT_16 */


### PR DESCRIPTION
This is a draft for now because I need to do a little more research to finish it up, but as-is I think any behaviors explicitly changed should be correct and everything else should be equivalent to before.

* `mplayer.c` had two separate vibrato tables for effect vibrato and autovibrato. Effect vibrato used a table of size 32 and effective period of 64,  but autovibrato had a table of size 128 (but with 1/4 the amplitude precision) and effective period of 256. I replaced them with a single table of size 128 and amplitudes from 0 to 255. I can't imagine there was any reason for making effect vibrato have lower precision than autovibrato.
* All of the commands using `VibratoTable` had the same waveform switch and math copypasted inline. Since most compilers newer than 1998 can automatically inline small functions I combined these to clean up some code.
* The one place these were different was the IT implementations of vibrato (Hxy) and fine vibrato (Uxy), which had the "ramp down" and "square" waveforms flipped. I verified with Impulse Tracker 2.14 that these should always have been the same IDs as their MOD/S3M equivalents, so I'm not sure why this was changed in the first place (might need a little research to determine why they were flipped...).
* Every waveform handler was computing "ramp down" as a ramp up, which is correct for vibrato (period ramp up results in pitch ramp down) but caused tremolo to ramp the wrong direction. There is a separate waveform function for tremolo to address this.

To do:
- [x] ~~I did not change anything in particular about autovibrato aside from the table it uses but it is definitely much weaker than it ought to be for Impulse Tracker modules, has square at index 1 (need to check whether this is correct), and has two different ramps in indices 2 and 3 (IT should have a random waveform). This probably needs to be handled carefully since this behavior might be derived from XM.~~
- [x] Fix XM sine autovibrato.
- [x] Fix IT autovibrato waveforms.
- [x] Fix IT autovibrato depth.
- [x] Fix random waveform.
- [x] ~~The ramp flipping flag is kind of a hack, and doesn't account for the other waveforms that might be flipped entirely for vibrato as well. This needs some more verification. edit: for what it's worth, both XM and IT autovibrato flips every waveform.~~ Confirmed that all IT new vibrato effects subtract their waveforms from the period.
- [x] ~~MikMod appears to be checking the wrong bit to determine whether to use the continuous variant of a given waveform.~~ It was, fixed now.
- [x] MikMod was applying the MOD quirk of ignoring vibrato on the first tick to everything using `DoVibrato`. This is now a flag specified by whatever uses it, and S3M/XM/old effects IT/MED now ignore it.
- [x] Added commands for old effects IT. The IT vibrato effects now all use `DoITVibrato` to avoid adding even more copypaste.
- [x] Panbrello had the same reversed waveforms issue as IT vibrato and also wasn't correctly resetting the waveform position at the start of a note. Random panbrello does something different from everything else that requires a new variable in `MP_CONTROL` (not sure if that's an ABI change...) so it's just broken for now.