### PR TITLE
Add WinMM driver command line options for buffer size and count.

### DIFF
--- a/libmikmod/drivers/drv_win.c
+++ b/libmikmod/drivers/drv_win.c
@@ -58,15 +58,40 @@ typedef DWORD DWORD_PTR;
 #define WAVE_FORMAT_IEEE_FLOAT 0x0003
 #endif
 
-#define NUMBUFFERS	6				/* number of buffers */
-#define BUFFERSIZE	120				/* buffer size in milliseconds */
+#define MINBUFFERS		2			/* min number of buffers */
+#define MAXBUFFERS		16			/* max number of buffers */
+#define MINBUFFERSIZE_MS	50			/* min buffer size in milliseconds */
+#define MAXBUFFERSIZE_MS	1000			/* max buffer size in milliseconds */
+
+#define DEFAULT_NUMBUFFERS	2
+#define DEFAULT_BUFFERSIZE_MS	120
 
 static HWAVEOUT	hwaveout;
-static WAVEHDR	header[NUMBUFFERS];
-static HPSTR	buffer[NUMBUFFERS];		/* pointers to buffers */
+static WAVEHDR	header[MAXBUFFERS];
+static HPSTR	buffer[MAXBUFFERS];		/* pointers to buffers */
 static WORD	buffersout;				/* number of buffers playing/about to be played */
 static WORD	nextbuffer;				/* next buffer to be mixed */
 static ULONG	buffersize;				/* buffer size in bytes */
+static ULONG	buffersize_ms = DEFAULT_BUFFERSIZE_MS;	/* configured buffer size in milliseconds */
+static ULONG	numbuffers = DEFAULT_NUMBUFFERS;	/* configured number of buffers */
+
+static void WIN_CommandLine(const CHAR *cmdline)
+{
+	CHAR *ptr;
+
+	if((ptr = MD_GetAtom("buffer",cmdline,0)) != NULL) {
+		buffersize_ms = atoi(ptr);
+		if(buffersize_ms < MINBUFFERSIZE_MS || buffersize_ms > MAXBUFFERSIZE_MS)
+			buffersize_ms = DEFAULT_BUFFERSIZE_MS;
+		MikMod_free(ptr);
+	}
+	if((ptr = MD_GetAtom("count",cmdline,0)) != NULL) {
+		numbuffers = atoi(ptr);
+		if(numbuffers < MINBUFFERS || numbuffers > MAXBUFFERS)
+			numbuffers = DEFAULT_NUMBUFFERS;
+		MikMod_free(ptr);
+	}
+}
 
 /* converts Windows error to libmikmod error */
 static int WIN_GetError(MMRESULT mmr)
@@ -125,9 +150,9 @@ static int WIN_Init(void)
 		return 1;
 	}
 
-	buffersize=md_mixfreq*samplesize*BUFFERSIZE/1000;
+	buffersize=md_mixfreq*samplesize*buffersize_ms/1000;
 
-	for (n=0;n<NUMBUFFERS;n++) {
+	for (n=0;n<numbuffers;n++) {
 		buffer[n]=(HPSTR)MikMod_malloc(buffersize);
 		header[n].lpData=buffer[n];
 		header[n].dwBufferLength=buffersize;
@@ -158,7 +183,7 @@ static void WIN_Exit(void)
 
 	VC_Exit();
 	if (hwaveout) {
-		for (n=0;n<NUMBUFFERS;n++) {
+		for (n=0;n<numbuffers;n++) {
 			if (header[n].dwFlags&WHDR_PREPARED)
 				waveOutUnprepareHeader(hwaveout,&header[n],sizeof(WAVEHDR));
 			MikMod_free(buffer[n]);
@@ -173,12 +198,12 @@ static void WIN_Update(void)
 {
 	ULONG done;
 
-	while (buffersout<NUMBUFFERS) {
+	while (buffersout<numbuffers) {
 		done=VC_WriteBytes((SBYTE*)buffer[nextbuffer],buffersize);
 		if (!done) break;
 		header[nextbuffer].dwBufferLength=done;
 		waveOutWrite(hwaveout,&header[nextbuffer],sizeof(WAVEHDR));
-		if (++nextbuffer>=NUMBUFFERS) nextbuffer%=NUMBUFFERS;
+		if (++nextbuffer>=numbuffers) nextbuffer%=numbuffers;
 		++buffersout;
 	}
 }
@@ -195,8 +220,9 @@ MIKMODAPI MDRIVER drv_win={
 	"Windows waveform-audio driver v0.2",
 	0,255,
 	"winmm",
-	NULL,
-	NULL,
+	"buffer:r:50,1000,120:Audio buffer size in milliseconds\n"
+	"count:r:2,16,2:Audio buffer count\n",
+	WIN_CommandLine,
 	WIN_IsThere,
 	VC_SampleLoad,
 	VC_SampleUnload,


### PR DESCRIPTION
Adds command line options to configure the number of buffers and size of buffers for the WinMM driver. The default 120ms buffer at 44100Hz works out to 5292 samples, which there definitely did not need to be 6(!) of, so the default buffer count is now 2 (can be configured up to 16 for the off chance someone's dinosaur machine actually needed 6 buffers). The minimum buffer size is 50ms because MikMod's WinMM output gets choppy below that point.

Fixes the WinMM related portions of #29. I don't have any ideas re: the OSS portions except that the MSYS2 OSS driver might just have a lot of latency.