### PR TITLE
Detect MSYS2 in configure.ac, include windows.h for dsound.h.

### DIFF
--- a/libmikmod/configure.ac
+++ b/libmikmod/configure.ac
@@ -52,6 +52,7 @@ libmikmod_hpux=no
 
 case $host_os in
 	mingw*) libmikmod_mingw=yes ;;
+	msys*) libmikmod_mingw=yes ;;
 	cygwin*) libmikmod_cygwin=yes ;;
 	linux*) libmikmod_linux=yes ;;
 	darwin*) libmikmod_darwin=yes ;;
@@ -792,13 +793,13 @@ AC_SUBST(SDL_LIBS)
 # Windows audio
 # ---------------------
 case $host_os in
- mingw*|cygwin*)
+ mingw*|msys*|cygwin*)
 	# do a windows.h check, just in case..
 	AC_CHECK_HEADERS([windows.h],,[AC_MSG_ERROR([Targeting windows, but windows.h not available])])
 	if test $libmikmod_driver_ds = yes
 	then
 		libmikmod_driver_ds=no
-		AC_CHECK_HEADERS([dsound.h],[libmikmod_driver_ds=yes])
+		AC_CHECK_HEADERS([dsound.h],[libmikmod_driver_ds=yes],[],[#include <windows.h>])
 	fi
 	if test $libmikmod_driver_xaudio2 = yes
 	then

--- a/libmikmod/drivers/drv_ds.c
+++ b/libmikmod/drivers/drv_ds.c
@@ -20,8 +20,6 @@
 
 /*==============================================================================
 
-  $Id$
-
   Driver for output on win32 platforms using DirectSound
 
 ==============================================================================*/
@@ -43,7 +41,18 @@
 #include <memory.h>
 #include <string.h>
 
+/* Including dsound.h breaks in MSYS2 unless windows.h is
+ * explicitly included first (without WIN32_LEAN_AND_MEAN).
+ */
+#include <windows.h>
+
 #define INITGUID
+#if defined(__LCC__)||defined(__WATCOMC__)
+#include <guiddef.h>
+#else
+#include <basetyps.h> /* guiddef.h not in all SDKs, e.g. mingw.org */
+#endif
+
 #if !defined(__cplusplus) && !defined(CINTERFACE)
 #define CINTERFACE
 #endif
@@ -58,7 +67,6 @@
  * https://github.com/open-watcom/open-watcom-v2/commit/961ef1ff756f3ec5a7248cefcae00a6ecaa97ff4
  * Therefore, we define and use a local copy of IID_IDirectSoundNotify here.
  */
-#include <guiddef.h>
 DEFINE_GUID(IID_IDirectSoundNotify,0xB0210783,0x89cd,0x11d0,0xAF,0x08,0x00,0xA0,0xC9,0x25,0xCD,0x16);
 #endif
 

--- a/libmikmod/include/mikmod.h
+++ b/libmikmod/include/mikmod.h
@@ -87,7 +87,7 @@ MIKMODAPI extern long MikMod_GetVersion(void);
  *  ========== Dependency platform headers
  */
 
-#ifdef _WIN32
+#if defined(_WIN32)||defined(__CYGWIN__)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -106,7 +106,7 @@ extern MikMod_handler_t _mm_errorhandler;
         if(_mm_mutex_##name)\
             DosReleaseMutexSem(_mm_mutex_##name)
 
-#elif defined(_WIN32)
+#elif defined(_WIN32)||defined(__CYGWIN__)
 #include <windows.h>
 #define DECLARE_MUTEX(name) \
         extern HANDLE _mm_mutex_##name


### PR DESCRIPTION
Fixes configury issues discussed in #29 by adding checks for MSYS2 to configure.ac. My environment also refuses to compile anything including dsound.h unless windows.h is included first, so I patched that as well (if it hurts anything this can be reverted).