### PR TITLE
Checks for extra "no loop" marker

### DIFF
--- a/libmikmod/loaders/load_669.c
+++ b/libmikmod/loaders/load_669.c
@@ -320,7 +320,7 @@ static BOOL S69_Load(BOOL curious)
 		sample.length=_mm_read_I_SLONG(modreader);
 		sample.loopbeg=_mm_read_I_SLONG(modreader);
 		sample.loopend=_mm_read_I_SLONG(modreader);
-		if (sample.loopend==0xfffff) sample.loopend=0;
+		if ((sample.loopend==0xfffff) || (sample.loopend==0xf0ffff)) sample.loopend=0;	/* No loop or special value used in Lost in Germany */
 
 		if((sample.length<0)||(sample.loopbeg<-1)||(sample.loopend<-1)) {
 			_mm_errno = MMERR_LOADING_HEADER;

--- a/libmikmod/loaders/load_669.c
+++ b/libmikmod/loaders/load_669.c
@@ -320,7 +320,7 @@ static BOOL S69_Load(BOOL curious)
 		sample.length=_mm_read_I_SLONG(modreader);
 		sample.loopbeg=_mm_read_I_SLONG(modreader);
 		sample.loopend=_mm_read_I_SLONG(modreader);
-		if ((sample.loopend==0xfffff) || (sample.loopend==0xf0ffff)) sample.loopend=0;	/* No loop or special value used in Lost in Germany */
+		if (sample.loopend>=0xfffff) sample.loopend=0;	/* No loop value or higher, which is used in Lost in Germany */
 
 		if((sample.length<0)||(sample.loopbeg<-1)||(sample.loopend<-1)) {
 			_mm_errno = MMERR_LOADING_HEADER;

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,7 +1157,7 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
-	if (speed >= 128)
+	if (speed > 128)
 		speed -= 128;
 	if (speed) {
 		mod->sngspd = speed;

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,7 +1157,7 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
-	if (speed > 128)
+	if (speed >= 128)
 		speed -= 128;
 	if (speed) {
 		mod->sngspd = speed;


### PR DESCRIPTION
In the module "Lost in Germary" by GMaxx (can be found on Modland) have another marker for the samples to indicate that they do not loop. Normal marker is 0x000fffff, but in this module, the marker is 0x00f0ffff. Therefore I have added this extra check.