### PR TITLE
Fixed a little bug in S3M effect A (set speed). 0x80 is also a negati…

### DIFF
--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,7 +1157,7 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
-	if (speed > 128)
+	if (speed >= 128)
 		speed -= 128;
 	if (speed) {
 		mod->sngspd = speed;


### PR DESCRIPTION
Fixed a little bug in S3M effect A (set speed). 0x80 is also a negative number, that's why the equal sign need to be there too. Found a module that sets the speed to 0x80, which made over a 2 minutes silence.

First I though that the bug need to be fixed in the DSMI/AMF loader, but found out that the issue is in fact in the player. Found module is attached. The speed is set at the end of the module.

[Metromania Partie 1.zip](https://github.com/sezero/mikmod/files/6445324/Metromania.Partie.1.zip)
