### PR TITLE
Different fixes to DSMI loader

### DIFF
--- a/libmikmod/loaders/load_amf.c
+++ b/libmikmod/loaders/load_amf.c
@@ -127,14 +127,10 @@ static BOOL AMF_UnpackTrack(MREADER* r)
 	if (r) {
 		tracksize=_mm_read_I_UWORD(r);
 
-		/* The original code in DSMI library read the byte, but it is not used.
-		   Normally, it is zero, but Avoid.amf (version 8) have a track where its not.
-		   This track is garbage, so check the value and skip the track. */
+		/* The original code in DSMI library read the byte,
+		   but it is not used, so we won't either */
 //		tracksize+=((ULONG)_mm_read_UBYTE(r))<<16;
-		if (_mm_read_UBYTE(r)!=0) {
-			_mm_fseek(modreader, tracksize*3, SEEK_CUR);
-			return 1;
-		}
+		_mm_read_UBYTE(r);
 
 		if (tracksize)
 			while(tracksize--) {
@@ -153,8 +149,10 @@ static BOOL AMF_UnpackTrack(MREADER* r)
 
 				}
 				/* invalid row (probably unexpected end of row) */
-				if (row>=64)
-					return 0;
+				if (row>=64) {
+					_mm_fseek(modreader, tracksize * 3, SEEK_CUR);
+					return 1;
+				}
 				if (cmd<0x7f) {
 					/* note, vol */
 					track[row].note=cmd;


### PR DESCRIPTION
This commit contains several fixes.

- Removed the failure if an effect is out-of-range, but ignored instead. This makes the module "Escape From Dulce Base" playable. Module attached.

- When porting this loader to C#, I noticed some strange thing, namely that the channel_remap array was defined as int, but loaded as bytes. The place where it is used, will then get some very high values and crash. Luckly?, this code was never executed, because of another bug. Version 10 modules, which have this remap table, did not use it. This is changed now.

- In the search for finding some modules that uses the channel_remap, I stumbled over Otto Chrons Github page, where the original DSMI code is published. There are some test modules, which are in version 8 and 9. I decided to add support for those versions, so they can be played. One of the modules is in version 14, but I have attached all of them anyway. In the progress, I made some addional fixes while analyzering Ottos loader.

[Escape From Dulce Base.zip](https://github.com/sezero/mikmod/files/6447002/Escape.From.Dulce.Base.zip)
[Test.zip](https://github.com/sezero/mikmod/files/6447017/Test.zip)