### PR TITLE
Added some fixes to Farandole modules.

### DIFF
--- a/libmikmod/include/mikmod.h
+++ b/libmikmod/include/mikmod.h
@@ -590,8 +590,6 @@ typedef struct MODULE {
     SWORD       sngpos;      /* current song position */
     ULONG       sngtime;     /* current song time in 2^-10 seconds */
 
-    UBYTE       farcurtempo; /* Farandole current speed */
-    SWORD       fartempobend;/* Used by the Farandole fine tempo effects and store the current bend value */
     SWORD       relspd;      /* relative speed factor */
 
  /* internal module representation */

--- a/libmikmod/include/mikmod.h
+++ b/libmikmod/include/mikmod.h
@@ -547,6 +547,7 @@ struct MP_VOICE;
 #define UF_FT2QUIRKS    0x0200 /* emulate some FT2 replay quirks */
 #define UF_PANNING      0x0400 /* module uses panning effects or have
                                   non-tracker default initial panning */
+#define UF_FARTEMPO     0x0800 /* Module uses Farandole tempo calculations */
 
 typedef struct MODULE {
  /* general module information */
@@ -589,6 +590,8 @@ typedef struct MODULE {
     SWORD       sngpos;      /* current song position */
     ULONG       sngtime;     /* current song time in 2^-10 seconds */
 
+    UBYTE       farcurtempo; /* Farandole current speed */
+    SWORD       fartempobend;/* Used by the Farandole fine tempo effects and store the current bend value */
     SWORD       relspd;      /* relative speed factor */
 
  /* internal module representation */

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -572,7 +572,8 @@ typedef struct MP_CONTROL {
     SBYTE   panbspd;    /* "" speed */
     UBYTE   panbdepth;  /* "" depth */
 
-    UWORD   newsamp;    /* set to 1 upon a sample / inst change */
+    UBYTE   newnote;    /* set to 1 if the current row contains a note */
+    UBYTE   newsamp;    /* set to 1 upon a sample / inst change */
     UBYTE   voleffect;  /* Volume Column Effect Memory as used by IT */
     UBYTE   voldata;    /* Volume Column Data Memory */
 

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -357,15 +357,15 @@ enum {
     UNI_MEDEFFECT_18,  /* stop note */
     UNI_MEDEFFECT_1E,  /* pattern delay */
     UNI_MEDEFFECT_1F,  /* note delay and retrigger */
-/* Farandole effects. */
-	UNI_FAREFFECT1,    /* Porta up */
+ /* Farandole effects. */
+    UNI_FAREFFECT1,    /* Porta up */
     UNI_FAREFFECT2,    /* Porta down */
     UNI_FAREFFECT3,    /* Porta to note */
     UNI_FAREFFECT4,    /* Retrigger */
     UNI_FAREFFECT6,    /* Vibrato */
     UNI_FAREFFECTD,    /* Fine tempo down */
     UNI_FAREFFECTE,    /* Fine tempo up */
-	UNI_FAREFFECTF,    /* Set tempo */
+    UNI_FAREFFECTF,    /* Set tempo */
 
     UNI_LAST
 };

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -537,8 +537,8 @@ typedef struct MP_CONTROL {
     SLONG   farcurrentvalue;     /* Because we're using fixing points as speed and the current period is an integer, we need to store the current value here for next round */
     UBYTE   farretrigcount;      /* Number of retrigs to do */
 
-    /* These two variables is only stored on the first control instance and therefore used globally.
-       The reason the are stored here, is to minimize the number of global variables */
+    /* These variables is only stored on the first control instance and therefore used globally.
+       The reason they are stored here, is to minimize the number of global variables */
 	UBYTE   farcurtempo;         /* Farandole current speed */
     SWORD   fartempobend;        /* Used by the Farandole fine tempo effects and store the current bend value */
 

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -537,6 +537,11 @@ typedef struct MP_CONTROL {
     SLONG   farcurrentvalue;     /* Because we're using fixing points as speed and the current period is an integer, we need to store the current value here for next round */
     UBYTE   farretrigcount;      /* Number of retrigs to do */
 
+    /* These two variables is only stored on the first control instance and therefore used globally.
+       The reason the are stored here, is to minimize the number of global variables */
+	UBYTE   farcurtempo;         /* Farandole current speed */
+    SWORD   fartempobend;        /* Used by the Farandole fine tempo effects and store the current bend value */
+
     UBYTE   glissando;  /* glissando (0 means off) */
     UBYTE   wavecontrol;
 

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -533,8 +533,8 @@ typedef struct MP_CONTROL {
     UBYTE   s3mrtgslide;/* last used retrig slide */
 
     UBYTE   fartoneportarunning; /* FAR tone porta (effect 3) is a little bit different than other effects. It should keep running when the effect has first started, even if it is not given on subsequently rows */
-    float   fartoneportaspeed;   /* FAR tone porta increment value */
-    float   farcurrentvalue;     /* Because we're using floats as speed and the current period is an integer, we need to store the current value here for next round */
+    SLONG   fartoneportaspeed;   /* FAR tone porta increment value */
+    SLONG   farcurrentvalue;     /* Because we're using fixing points as speed and the current period is an integer, we need to store the current value here for next round */
     UBYTE   farretrigcount;      /* Number of retrigs to do */
 
     UBYTE   glissando;  /* glissando (0 means off) */

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -357,6 +357,15 @@ enum {
     UNI_MEDEFFECT_18,  /* stop note */
     UNI_MEDEFFECT_1E,  /* pattern delay */
     UNI_MEDEFFECT_1F,  /* note delay and retrigger */
+/* Farandole effects. */
+	UNI_FAREFFECT1,    /* Porta up */
+    UNI_FAREFFECT2,    /* Porta down */
+    UNI_FAREFFECT3,    /* Porta to note */
+    UNI_FAREFFECT4,    /* Retrigger */
+    UNI_FAREFFECT6,    /* Vibrato */
+    UNI_FAREFFECTD,    /* Fine tempo down */
+    UNI_FAREFFECTE,    /* Fine tempo up */
+	UNI_FAREFFECTF,    /* Set tempo */
 
     UNI_LAST
 };
@@ -522,6 +531,11 @@ typedef struct MP_CONTROL {
     SBYTE   sliding;
     UBYTE   s3mrtgspeed;/* last used retrig speed */
     UBYTE   s3mrtgslide;/* last used retrig slide */
+
+    UBYTE   fartoneportarunning; /* FAR tone porta (effect 3) is a little bit different than other effects. It should keep running when the effect has first started, even if it is not given on subsequently rows */
+    float   fartoneportaspeed;   /* FAR tone porta increment value */
+    float   farcurrentvalue;     /* Because we're using floats as speed and the current period is an integer, we need to store the current value here for next round */
+    UBYTE   farretrigcount;      /* Number of retrigs to do */
 
     UBYTE   glissando;  /* glissando (0 means off) */
     UBYTE   wavecontrol;

--- a/libmikmod/include/mikmod_internals.h
+++ b/libmikmod/include/mikmod_internals.h
@@ -537,9 +537,9 @@ typedef struct MP_CONTROL {
     SLONG   farcurrentvalue;     /* Because we're using fixing points as speed and the current period is an integer, we need to store the current value here for next round */
     UBYTE   farretrigcount;      /* Number of retrigs to do */
 
-    /* These variables is only stored on the first control instance and therefore used globally.
-       The reason they are stored here, is to minimize the number of global variables */
-	UBYTE   farcurtempo;         /* Farandole current speed */
+    /* These variables are only stored on the first control instance and therefore used globally.
+       The reason they are stored here is to minimize the number of global variables.  */
+    UBYTE   farcurtempo;         /* Farandole current speed */
     SWORD   fartempobend;        /* Used by the Farandole fine tempo effects and store the current bend value */
 
     UBYTE   glissando;  /* glissando (0 means off) */

--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -205,7 +205,7 @@ static UBYTE *FAR_ConvertTrack(FARNOTE* n,int rows)
 
 static BOOL FAR_Load(BOOL curious)
 {
-	int t,u,tracks=0;
+	int r,t,u,tracks=0;
 	SAMPLE *q;
 	FARSAMPLE s;
 	FARNOTE *crow;
@@ -321,10 +321,9 @@ static BOOL FAR_Load(BOOL curious)
 			// Farandole Composer normally use a 64 rows blank track for patterns with 0 rows
 			for (u = 0; u < 16; u++) {
 				UniReset();
-
-				for (int r = 0; r < 64; r++)
+				for (r = 0; r < 64; r++) {
 					UniNewline();
-
+				}
 				of.tracks[tracks++] = UniDup();
 			}
 			of.pattrows[t] = 64;

--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -345,7 +345,12 @@ static BOOL FAR_Load(BOOL curious)
 			q->loopend    = s.repend;
 			q->volume     = s.volume<<2;
 
-			if(s.type&1) q->flags|=SF_16BITS;
+			if(s.type&1) {
+				q->flags|=SF_16BITS;
+				q->length >>= 1;
+				q->loopstart >>= 1;
+				q->loopend >>= 1;
+			}
 
 			/* It is not always the case that this bit is set, e.g. "Budda on a bicycle" has not.
 			   So we check the loop start and end instead */
@@ -354,7 +359,7 @@ static BOOL FAR_Load(BOOL curious)
 				q->flags |= SF_LOOP;
 
 			q->seekpos    = _mm_ftell(modreader);
-			_mm_fseek(modreader,q->length,SEEK_CUR);
+			_mm_fseek(modreader,s.length,SEEK_CUR);
 		} else
 			q->samplename = MikMod_strdup("");
 		q++;

--- a/libmikmod/loaders/load_far.c
+++ b/libmikmod/loaders/load_far.c
@@ -138,6 +138,16 @@ static UBYTE *FAR_ConvertTrack(FARNOTE* n,int rows)
 		if (n->vol>=0x01 && n->vol<=0x10) UniPTEffect(0xc,(n->vol - 1)<<2);
 		if (n->eff)
 			switch(n->eff>>4) {
+				case 0x0: /* global effects */
+					switch(n->eff & 0xf) {
+						case 0x3:	/* fulfill loop */
+							UniEffect(UNI_KEYFADE, 0);
+							break;
+						case 0x4:	/* old tempo mode */
+						case 0x5:	/* new tempo mode */
+							break;
+					}
+					break;
 				case 0x1: /* pitch adjust up */
 					UniEffect(UNI_FAREFFECT1, n->eff & 0xf);
 					break;
@@ -162,8 +172,12 @@ static UBYTE *FAR_ConvertTrack(FARNOTE* n,int rows)
 				case 0x8: /* volume slide down */
 					UniPTEffect(0xa,n->eff&0xf);
 					break;
+				case 0x9: /* sustained vibrato */
+					break;
 				case 0xb: /* panning */
 					UniPTEffect(0xe,0x80|(n->eff&0xf));
+					break;
+				case 0xc: /* note offset */
 					break;
 				case 0xd: /* fine tempo down */
 					UniEffect(UNI_FAREFFECTD, n->eff & 0xf);

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -2278,7 +2278,7 @@ static int DoOktArp(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD c
 
 /*========== Farandole effects */
 
-static void DoFarTonePorta(MP_CONTROL* a)
+static void DoFarTonePorta(MP_CONTROL *a)
 {
 	if (!a->main.fadevol)
 		a->main.kick = (a->main.kick == KICK_NOTE) ? KICK_NOTE : KICK_KEYOFF;
@@ -2289,14 +2289,12 @@ static void DoFarTonePorta(MP_CONTROL* a)
 
 	/* Have we reached our note */
 	BOOL reachedNote = (a->fartoneportaspeed > 0) ? (a->farcurrentvalue >> 16) >= a->wantedperiod : (a->farcurrentvalue >> 16) <= a->wantedperiod;
-	if (reachedNote)
-	{
+	if (reachedNote) {
 		/* Stop the porta and set the periods to the reached note */
 		a->tmpperiod = a->main.period = a->wantedperiod;
 		a->fartoneportarunning = 0;
 	}
-	else
-	{
+	else {
 		/* Do the porta */
 		a->tmpperiod = a->main.period = (UWORD)(a->farcurrentvalue >> 16);
 	}
@@ -2311,7 +2309,7 @@ static SLONG GetFARTempoFactor()
 }
 
 /* Set the right speed and BPM for Farandole modules */
-static void SetFARTempo(MODULE* mod)
+static void SetFARTempo(MODULE *mod)
 {
 	/* According to the Farandole document, the tempo of the song is 32/tempo notes per second.
 	   So if we set tempo to 1, we will get 32 notes per second. We then need to translate this
@@ -2367,8 +2365,7 @@ static void SetFARTempo(MODULE* mod)
 	SLONG eax = gus;
 	UBYTE cx = 0, di = 0;
 
-	while (eax > 0xffff)
-	{
+	while (eax > 0xffff) {
 		eax >>= 1;
 		di++;
 		cx++;
@@ -2384,7 +2381,7 @@ static void SetFARTempo(MODULE* mod)
 	mod->bpm = (80 * mod->sngspd) / factor;
 }
 
-static int DoFAREffect1(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffect1(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
@@ -2400,7 +2397,7 @@ static int DoFAREffect1(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffect2(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffect2(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
@@ -2416,12 +2413,11 @@ static int DoFAREffect2(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffect3(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffect3(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
-	if (!tick)
-	{
+	if (!tick) {
 		/* We have to slide a.Main.Period toward a.WantedPeriod,
 		  compute the difference between those two values */
 		SLONG dist = a->wantedperiod - a->main.period;
@@ -2440,27 +2436,22 @@ static int DoFAREffect3(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffect4(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffect4(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
 	/* Here the argument is the number of retrigs to play evenly
 	   spaced in the current row */
-	if (!tick)
-	{
-		if (dat)
-		{
+	if (!tick) {
+		if (dat) {
 			a->farretrigcount = dat;
 			a->retrig = 0;
 		}
 	}
 
-	if (dat)
-	{
-		if (!a->retrig)
-		{
-			if (a->farretrigcount > 0)
-			{
+	if (dat) {
+		if (!a->retrig) {
+			if (a->farretrigcount > 0) {
 				/* When retrig counter reaches 0,
 				   reset counter and restart the sample */
 				if (a->main.period != 0)
@@ -2478,7 +2469,7 @@ static int DoFAREffect4(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffect6(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffect6(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat;
 
@@ -2493,12 +2484,11 @@ static int DoFAREffect6(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffectD(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffectD(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
-	if (dat != 0)
-	{
+	if (dat != 0) {
 		fartempobend -= dat;
 
 		if ((fartempobend + GetFARTempoFactor()) <= 0)
@@ -2512,12 +2502,11 @@ static int DoFAREffectD(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffectE(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffectE(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
-	if (dat != 0)
-	{
+	if (dat != 0) {
 		fartempobend += dat;
 
 		if ((fartempobend + GetFARTempoFactor()) >= 100)
@@ -2531,12 +2520,11 @@ static int DoFAREffectE(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 	return 0;
 }
 
-static int DoFAREffectF(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWORD channel)
+static int DoFAREffectF(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWORD channel)
 {
 	UBYTE dat = UniGetByte();
 
-	if (!tick)
-	{
+	if (!tick) {
 		farcurtempo = dat;
 		mod->vbtick = 0;
 

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -2416,14 +2416,21 @@ static int DoFAREffect3(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 		/* We have to slide a.Main.Period toward a.WantedPeriod,
 		  compute the difference between those two values */
 		SLONG dist = a->wantedperiod - a->main.period;
+		SWORD tempo = GetFARTempo(mod);
 
 		/* Adjust effect argument */
 		if (dat == 0)
 			dat = 1;
+		/* This causes crashes and other weird behavior in Farandole Composer. */
+		if (tempo <= 0)
+			tempo = 1;
 
-		/* Unlike other players, the data is how many rows the port
-		   should take and not a speed */
-		a->fartoneportaspeed = (dist << 16) / (mod->sngspd * dat);
+		/* The data is supposed to be the number of rows until completion of
+		   the slide, but because it's Farandole Composer, it isn't. While
+		   that claim holds for tempo 4, for tempo 2 it takes param*2 rows,
+		   for tempo 1 it takes param*4 rows, etc. This calculation is based
+		   on the final tempo/interrupts per second count. */
+		a->fartoneportaspeed = (dist << 16) * 8 / (tempo * dat);
 		a->farcurrentvalue = (SLONG)a->main.period << 16;
 		a->fartoneportarunning = 1;
 	}

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -2354,7 +2354,7 @@ static void SetFARTempo(MODULE *mod)
 
 	   You can make yourself a little exercise to prove that the above is correct :-) */
 
-	UWORD realTempo = mod->control[0].fartempobend + GetFARTempoFactor(&mod->control[0]);
+	SWORD realTempo = mod->control[0].fartempobend + GetFARTempoFactor(&mod->control[0]);
 
 	SLONG gus = 1197255 / realTempo;
 
@@ -2523,8 +2523,15 @@ static int DoFAREffectF(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	UBYTE dat = UniGetByte();
 
 	if (!tick) {
-		mod->control[0].farcurtempo = dat;
+		MP_CONTROL *firstControl = &mod->control[0];
+
+		firstControl->farcurtempo = dat;
 		mod->vbtick = 0;
+
+		if ((firstControl->fartempobend + GetFARTempoFactor(firstControl)) <= 0)
+			firstControl->fartempobend = 0;
+		else if ((firstControl->fartempobend + GetFARTempoFactor(firstControl)) >= 100)
+			firstControl->fartempobend = 100;
 
 		SetFARTempo(mod);
 	}

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -2355,6 +2355,8 @@ static void SetFARTempo(MODULE *mod)
 	   You can make yourself a little exercise to prove that the above is correct :-) */
 
 	SWORD realTempo = mod->control[0].fartempobend + GetFARTempoFactor(&mod->control[0]);
+	if (!realTempo)
+		return;
 
 	SLONG gus = 1197255 / realTempo;
 

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -2385,12 +2385,14 @@ static int DoFAREffect1(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 {
 	UBYTE dat = UniGetByte();
 
-	a->slidespeed = (UWORD)dat << 2;
+	if (!tick) {
+		a->slidespeed = (UWORD)dat << 2;
 
-	if (a->main.period)
-		a->tmpperiod -= a->slidespeed;
+		if (a->main.period)
+			a->tmpperiod -= a->slidespeed;
 
-	a->fartoneportarunning = 0;
+		a->fartoneportarunning = 0;
+	}
 
 	return 0;
 }
@@ -2399,12 +2401,14 @@ static int DoFAREffect2(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 {
 	UBYTE dat = UniGetByte();
 
-	a->slidespeed = (UWORD)dat << 2;
+	if (!tick) {
+		a->slidespeed = (UWORD)dat << 2;
 
-	if (a->main.period)
-		a->tmpperiod += a->slidespeed;
+		if (a->main.period)
+			a->tmpperiod += a->slidespeed;
 
-	a->fartoneportarunning = 0;
+		a->fartoneportarunning = 0;
+	}
 
 	return 0;
 }

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -52,6 +52,10 @@ extern long int random(void);
 /* The currently playing module */
 MODULE *pf = NULL;
 
+/* Different playing information */
+UBYTE farcurtempo;   /* Farandole current speed */
+SWORD fartempobend;  /* Used by the Farandole fine tempo effects and store the current bend value */
+
 #define NUMVOICES(mod) (md_sngchn < (mod)->numvoices ? md_sngchn : (mod)->numvoices)
 
 #define	HIGH_OCTAVE		2	/* number of above-range octaves */
@@ -2303,9 +2307,9 @@ static void DoFarTonePorta(MP_CONTROL* a)
 }
 
 /* Find tempo factor */
-static int GetFARTempoFactor(MODULE* mod)
+static int GetFARTempoFactor()
 {
-	return mod->farcurtempo == 0 ? 256 : (128 / mod->farcurtempo);
+	return farcurtempo == 0 ? 256 : (128 / farcurtempo);
 }
 
 /* Set the right speed and BPM for Farandole modules */
@@ -2358,7 +2362,7 @@ static void SetFARTempo(MODULE* mod)
 
 	   You can make yourself a little exercise to prove that the above is correct :-) */
 
-	WORD realTempo = mod->fartempobend + GetFARTempoFactor(mod);
+	WORD realTempo = fartempobend + GetFARTempoFactor();
 
 	int gus = 1197255 / realTempo;
 
@@ -2465,7 +2469,7 @@ static int DoFAREffect4(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 
 				a->farretrigcount--;
 				if (a->farretrigcount > 0)
-					a->retrig = ((mod->fartempobend + GetFARTempoFactor(mod)) / dat / 8) - 1;
+					a->retrig = ((fartempobend + GetFARTempoFactor()) / dat / 8) - 1;
 			}
 		}
 		else
@@ -2496,13 +2500,13 @@ static int DoFAREffectD(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 
 	if (dat != 0)
 	{
-		mod->fartempobend -= dat;
+		fartempobend -= dat;
 
-		if ((mod->fartempobend + GetFARTempoFactor(mod)) <= 0)
-			mod->fartempobend = 0;
+		if ((fartempobend + GetFARTempoFactor()) <= 0)
+			fartempobend = 0;
 	}
 	else
-		mod->fartempobend = 0;
+		fartempobend = 0;
 
 	SetFARTempo(mod);
 	
@@ -2515,13 +2519,13 @@ static int DoFAREffectE(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 
 	if (dat != 0)
 	{
-		mod->fartempobend += dat;
+		fartempobend += dat;
 
-		if ((mod->fartempobend + GetFARTempoFactor(mod)) >= 100)
-			mod->fartempobend = 100;
+		if ((fartempobend + GetFARTempoFactor()) >= 100)
+			fartempobend = 100;
 	}
 	else
-		mod->fartempobend = 0;
+		fartempobend = 0;
 
 	SetFARTempo(mod);
 
@@ -2534,7 +2538,7 @@ static int DoFAREffectF(UWORD tick, UWORD flags, MP_CONTROL* a, MODULE* mod, SWO
 
 	if (!tick)
 	{
-		mod->farcurtempo = dat;
+		farcurtempo = dat;
 		mod->vbtick = 0;
 
 		SetFARTempo(mod);
@@ -3328,8 +3332,8 @@ void Player_HandleTick(void)
 				if (!(pf->sngpos=pf->reppos)) {
 				    pf->volume=pf->initvolume>128?128:pf->initvolume;
 					if (pf->flags & UF_FARTEMPO) {
-						pf->farcurtempo = pf->initspeed;
-						pf->fartempobend = 0;
+						farcurtempo = pf->initspeed;
+						fartempobend = 0;
 						SetFARTempo(pf);
 					}
 					else {
@@ -3381,8 +3385,8 @@ static void Player_Init_internal(MODULE* mod)
 	mod->sngpos=0;
 
 	if (mod->flags & UF_FARTEMPO) {
-		mod->farcurtempo = mod->initspeed;
-		mod->fartempobend = 0;
+		farcurtempo = mod->initspeed;
+		fartempobend = 0;
 		SetFARTempo(mod);
 	}
 	else {

--- a/libmikmod/playercode/munitrk.c
+++ b/libmikmod/playercode/munitrk.c
@@ -113,6 +113,14 @@ const UWORD unioperands[UNI_LAST] = {
 	1, /* UNI_MEDEFFECT_18 */
 	1, /* UNI_MEDEFFECT_1E */
 	1, /* UNI_MEDEFFECT_1F */
+	1, /* UNI_FAREFFECT1 */
+	1, /* UNI_FAREFFECT2 */
+	1, /* UNI_FAREFFECT3 */
+	1, /* UNI_FAREFFECT4 */
+	1, /* UNI_FAREFFECT6 */
+	1, /* UNI_FAREFFECTD */
+	1, /* UNI_FAREFFECTE */
+	1, /* UNI_FAREFFECTF */
 };
 
 /* Sparse description of the internal module format


### PR DESCRIPTION
1. Fixed loop detection. "Budda on a bicycle" have a looped sample without the flag set.
2. Fixed the player to handle empty rows (row number = 0). "Alterations of time" have that at the last position.
3. Handle invalid pattern numbers in position list. "Beyond the shores of avalon" have that at the last two positions.
4. Added support for effect 1 and 2 (porta slide up/down).
5. Implemented effect 3 (tone porta) the right way (hopefully) by adding a new effect. Implementation is based on documentation by Daniel Potter found at Modland + the original player code. This makes "Amazon dawn" sound better.
6. Now plays with the real tempos. Farandole uses another concept than all other players to find the tempo.
7. Added support for effect D and E (fine tempo up/down). "A journey into sound" uses this a lot.
8. Fixed effect 6 (vibrato) by adding a new effect. The PT vibrato effect was too slow + it also need to increment on tick 0. "A journey into sound" sounds better now.
9. Fixed effect 4 (retrigger) by adding a new effect. The argument is not a delay count, but number of times to retrig.

I will say, after these fixes, MikMod and NostalgicPlayer will be the most accourate player of Farandole modules there exists, except the Farandole itself. All players I have tested with, have different issues, mostly with the speed and note portamento.

There are still some effects that need to be implemented, but I could not find any modules that uses them. Modules mentioned above is attached.

[TestModules.zip](https://github.com/sezero/mikmod/files/6479659/TestModules.zip)