### PR TITLE
Some small fixes for ScreamTracker 2

### DIFF
--- a/libmikmod/loaders/load_stm.c
+++ b/libmikmod/loaders/load_stm.c
@@ -325,7 +325,6 @@ static BOOL STM_Load(BOOL curious)
 			return 0;
 		}
 	}
-	if(mh->patorder[t]<=99) t++;
 	of.numpos=t;
 	of.numtrk=of.numpat*of.numchn;
 	of.numins=of.numsmp=31;
@@ -376,8 +375,13 @@ static BOOL STM_Load(BOOL curious)
 		/* contrary to the STM specs, sample data is signed */
 		q->flags = SF_SIGNED;
 
-		if(q->loopend && q->loopend != 0xffff)
-				q->flags|=SF_LOOP;
+		if(q->loopend && q->loopend != 0xffff && q->loopstart < q->length) {
+			q->flags|=SF_LOOP;
+			if (q->loopend > q->length)
+				q->loopend = q->length;
+		}
+		else
+			q->loopstart = q->loopend = 0;
 	}
 	return 1;
 }


### PR DESCRIPTION
1. One extra position was always added, which made the player to play the first pattern at the end.
2. Fixed sample loop and detection for invalid values, e.g. N.S. Beat.stm and Batman.stm.

[stm_mods.zip](https://github.com/sezero/mikmod/files/6502044/stm_mods.zip)