### PR TITLE
Reset channels

### DIFF
--- a/libmikmod/loaders/load_669.c
+++ b/libmikmod/loaders/load_669.c
@@ -320,7 +320,7 @@ static BOOL S69_Load(BOOL curious)
 		sample.length=_mm_read_I_SLONG(modreader);
 		sample.loopbeg=_mm_read_I_SLONG(modreader);
 		sample.loopend=_mm_read_I_SLONG(modreader);
-		if (sample.loopend==0xfffff) sample.loopend=0;
+		if ((sample.loopend==0xfffff) || (sample.loopend==0xf0ffff)) sample.loopend=0;	/* No loop or special value used in Lost in Germany */
 
 		if((sample.length<0)||(sample.loopbeg<-1)||(sample.loopend<-1)) {
 			_mm_errno = MMERR_LOADING_HEADER;

--- a/libmikmod/loaders/load_669.c
+++ b/libmikmod/loaders/load_669.c
@@ -320,7 +320,7 @@ static BOOL S69_Load(BOOL curious)
 		sample.length=_mm_read_I_SLONG(modreader);
 		sample.loopbeg=_mm_read_I_SLONG(modreader);
 		sample.loopend=_mm_read_I_SLONG(modreader);
-		if ((sample.loopend==0xfffff) || (sample.loopend==0xf0ffff)) sample.loopend=0;	/* No loop or special value used in Lost in Germany */
+		if (sample.loopend>=0xfffff) sample.loopend=0;	/* No loop value or higher, which is used in Lost in Germany */
 
 		if((sample.length<0)||(sample.loopbeg<-1)||(sample.loopend<-1)) {
 			_mm_errno = MMERR_LOADING_HEADER;

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,7 +1157,7 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
-	if (speed >= 128)
+	if (speed > 128)
 		speed -= 128;
 	if (speed) {
 		mod->sngspd = speed;

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -3042,12 +3042,25 @@ void Player_HandleTick(void)
 				(pf->positions[pf->sngpos]==LAST_PATTERN)) {
 				if (!pf->wrap) return;
 				if (!(pf->sngpos=pf->reppos)) {
-				    pf->volume=pf->initvolume>128?128:pf->initvolume;
+					int t;
+
+					pf->volume=pf->initvolume>128?128:pf->initvolume;
 					if(pf->initspeed!=0)
 						pf->sngspd=pf->initspeed<32?pf->initspeed:32;
 					else
 						pf->sngspd=6;
 					pf->bpm=pf->inittempo<32?32:pf->inittempo;
+
+					/* Re-initialize all channels */
+					for (t = 0; t < pf->numchn; t++)
+					{
+						memset(&pf->control[t], 0, sizeof(MP_CONTROL));
+
+						pf->control[t].main.chanvol = pf->chanvol[t];
+						pf->control[t].main.panning = pf->panning[t];
+
+						Voice_Stop_internal(t);
+					}
 				}
 			}
 		}

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,7 +1157,7 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
-	if (speed > 128)
+	if (speed >= 128)
 		speed -= 128;
 	if (speed) {
 		mod->sngspd = speed;


### PR DESCRIPTION
If you have set so the module loops instead of stop, then all channels are now cleared. This can e.g. be heard in "7 seconds.s3m", where some chords are hanging.

[7 Seconds.zip](https://github.com/sezero/mikmod/files/6527744/7.Seconds.zip)
