### PR TITLE
UltraTracker fixes

### DIFF
--- a/libmikmod/loaders/load_ult.c
+++ b/libmikmod/loaders/load_ult.c
@@ -247,6 +247,10 @@ static BOOL ULT_Load(BOOL curious)
 
 	for(t=0;t<of.numtrk;t++) {
 		int rep,row=0;
+		/* FIXME: unrolling continuous portamento is a HACK and needs to
+		 * be replaced with a real continuous effect. This implementation
+		 * breaks when tone portamento continues between patterns. See
+		 * discussion in https://github.com/sezero/mikmod/pull/40 . */
 		int continuePortaToNote = 0;
 
 		UniReset();

--- a/libmikmod/loaders/load_ult.c
+++ b/libmikmod/loaders/load_ult.c
@@ -39,7 +39,6 @@
 #include <memory.h>
 #endif
 #include <string.h>
-#include <math.h>
 
 #include "mikmod_internals.h"
 


### PR DESCRIPTION
Just made some small fixes:

1. Fixed sample speed to calculate it correctly by using the original formula with floating points. "Break the beat" have a beat that runs too fast, because of miscalculation before.
2. Portamento to note fixed. According to the documentation, it should keep run until it reaches the note, even if other effects are running. "Consolidation" module has two porta in the beginning of the song and before the fix, it reached a false tone, because it didn't continue.
3. Clear invalid loop values. Some modules has values when loop is not set.

[UltraTracker.zip](https://github.com/sezero/mikmod/files/6539352/UltraTracker.zip)
