### PR TITLE
Allow speeds values of 128-255 for S3M/IT/DSMI/GDM/IMF.

### DIFF
--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -1157,8 +1157,18 @@ static int DoS3MEffectA(UWORD tick, UWORD flags, MP_CONTROL *a, MODULE *mod, SWO
 	if (tick || mod->patdly2)
 		return 0;
 
+#if 0
+	/* This was added between MikMod 3.1.2 and libmikmod 3.1.5 with
+	 * no documentation justifying its inclusion. Players for relevant
+	 * formats (S3M, IT, DSMI AMF, GDM, IMF) all allow values between
+	 * 128 and 255, so it's not clear what the purpose of this was.
+	 * See the following pull request threads:
+	 *
+	 * https://github.com/sezero/mikmod/pull/42
+	 * https://github.com/sezero/mikmod/pull/35 */
 	if (speed > 128)
 		speed -= 128;
+#endif
 	if (speed) {
 		mod->sngspd = speed;
 		mod->vbtick = 0;


### PR DESCRIPTION
Here is my alternate solution to pull request #35, as requested by @sezero. All investigation re: this patch is in the comments for that pull request, but the short version is the S3M, IT, DSMI, GDM, and IMF formats (which all use `UNI_S3MEFFECTA`) all allow speed values of 128-255. It's not clear why MikMod didn't allow this (maybe `mod->sngspd` was originally a signed char?).