### PR TITLE
STM patterns >=numpat should be handled as blank patterns.

### DIFF
--- a/libmikmod/loaders/load_stm.c
+++ b/libmikmod/loaders/load_stm.c
@@ -225,7 +225,7 @@ static UBYTE *STM_ConvertTrack(STMNOTE *n)
 	return UniDup();
 }
 
-static BOOL STM_LoadPatterns(void)
+static BOOL STM_LoadPatterns(int pattoload)
 {
 	int t,s,tracks=0;
 
@@ -233,7 +233,7 @@ static BOOL STM_LoadPatterns(void)
 	if(!AllocTracks()) return 0;
 
 	/* Allocate temporary buffer for loading and converting the patterns */
-	for(t=0;t<of.numpat;t++) {
+	for(t=0;t<pattoload;t++) {
 		for(s=0;s<(64U*of.numchn);s++) {
 			stmbuf[s].note   = _mm_read_UBYTE(modreader);
 			stmbuf[s].insvol = _mm_read_UBYTE(modreader);
@@ -254,6 +254,8 @@ static BOOL STM_LoadPatterns(void)
 
 static BOOL STM_Load(BOOL curious)
 {
+	BOOL blankpattern=0;
+	int pattoload;
 	int t;
 	ULONG samplestart;
 	ULONG sampleend;
@@ -318,19 +320,34 @@ static BOOL STM_Load(BOOL curious)
 	t=0;
 	if(!AllocPositions(0x80)) return 0;
 	/* 99 terminates the patorder list */
-	while((mh->patorder[t]<=99)&&(mh->patorder[t]<mh->numpat)) {
+	while(mh->patorder[t]<99) {
 		of.positions[t]=mh->patorder[t];
+
+		/* Screamtracker 2 treaks patterns >= numpat as blank patterns.
+		 * Example modules: jimmy.stm, Rauno/dogs.stm, Skaven/hevijanis istu maas.stm.
+		 *
+		 * Patterns>=64 have unpredictable behavior in Screamtracker 2,
+		 * but nothing seems to rely on them, so they're OK to blank too.
+		 */
+		if(of.positions[t]>=mh->numpat) {
+			of.positions[t]=mh->numpat;
+			blankpattern=1;
+		}
+
 		if(++t == 0x80) {
 			_mm_errno = MMERR_NOT_A_MODULE;
 			return 0;
 		}
 	}
+	/* Allocate an extra blank pattern if the module references one. */
+	pattoload=of.numpat;
+	if(blankpattern) of.numpat++;
 	of.numpos=t;
 	of.numtrk=of.numpat*of.numchn;
 	of.numins=of.numsmp=31;
 
 	if(!AllocSamples()) return 0;
-	if(!STM_LoadPatterns()) return 0;
+	if(!STM_LoadPatterns(pattoload)) return 0;
 
 	samplestart=_mm_ftell(modreader);
 	_mm_fseek(modreader,0,SEEK_END);


### PR DESCRIPTION
In Screamtracker 2, patterns >=numpat and <64 are always valid and treated as blank patterns. MikMod was preserving the out of bounds pattern values but not allocating a blank pattern for them, resulting in these patterns being skipped. Several STM modules use these blank patterns at the end of their order list, presumably to act as a break so the user can switch modules, or to let samples finish.

Fixes #9.