### PR TITLE
Implement MODPlugin ADPCM4 support for MOD, S3M, IT modules.

### DIFF
--- a/libmikmod/loaders/load_it.c
+++ b/libmikmod/loaders/load_it.c
@@ -705,7 +705,8 @@ static BOOL IT_Load(BOOL curious)
 		if(s.flag&16) q->flags|=SF_LOOP;
 		if(s.flag&64) q->flags|=SF_BIDI;
 
-		if(mh->cwt>=0x200) {
+		if(s.convert==0xff) q->flags|=SF_ADPCM4|SF_SIGNED; /* MODPlugin ADPCM */
+		else if(mh->cwt>=0x200) {
 			if(s.convert&1) q->flags|=SF_SIGNED;
 			if(s.convert&4) q->flags|=SF_DELTA;
 		}

--- a/libmikmod/loaders/load_s3m.c
+++ b/libmikmod/loaders/load_s3m.c
@@ -403,6 +403,7 @@ static BOOL S3M_Load(BOOL curious)
 		if(s.flags&1) q->flags |= SF_LOOP;
 		if(s.flags&4) q->flags |= SF_16BITS;
 		if(mh->fileformat==1) q->flags |= SF_SIGNED;
+		if(s.pack==4) q->flags |= SF_ADPCM4 | SF_SIGNED; /* MODPlugin ADPCM4. */
 
 		/* don't load sample if it doesn't have the SCRS tag */
 		if(memcmp(s.scrs,"SCRS",4)) q->length = 0;


### PR DESCRIPTION
Follow up commit to #57. This adds support for ADPCM4 samples in MOD, S3M, and IT modules (the prior commit added a loader and support for XM only). I also cleaned up the ADPCM4 loader a little bit—it didn't need a malloc for 16 bytes, the declarations needed to be fixed to be ANSI C compliant, etc.

MOD test module: [fairli.mod.zip](https://github.com/sezero/mikmod/files/7317070/fairli.mod.zip)
S3M test module: [mm2flash.s3m.zip](https://github.com/sezero/mikmod/files/7317071/mm2flash.s3m.zip)
XM test module: [MRHPx-HBTN LUCiFER.xm.zip](https://github.com/sezero/mikmod/files/7317072/MRHPx-HBTN.LUCiFER.xm.zip)
IT test module: [another life.it.zip](https://github.com/sezero/mikmod/files/7317069/another.life.it.zip)