### PR TITLE
Fix minor issues in depackers found by fuzzing libxmp.

### DIFF
--- a/libmikmod/depackers/pp20.c
+++ b/libmikmod/depackers/pp20.c
@@ -165,6 +165,7 @@ BOOL PP20_Unpack(MREADER* reader, void** out, long* outlen)
 	destlen |= tmp[1] << 8;
 	destlen |= tmp[2];
 	skip = tmp[3];
+	if (skip > 32) return 0;
 
 	_mm_fseek(reader,4,SEEK_SET);
 	_mm_read_UBYTES(tmp,4,reader);

--- a/libmikmod/depackers/xpk.c
+++ b/libmikmod/depackers/xpk.c
@@ -466,7 +466,7 @@ BOOL XPK_Unpack(MREADER *reader, void **out, long *outlen)
 	if (destlen < 0 || destlen > 0x200000)
 		return 0;
 
-	if ((src = (UBYTE*) MikMod_malloc(srclen + 3)) == NULL)
+	if ((src = (UBYTE*) MikMod_calloc(1, srclen + 3)) == NULL)
 		return 0;
 	if ((dest = (UBYTE*) MikMod_malloc(destlen + 100)) == NULL) {
 		MikMod_free(src);


### PR DESCRIPTION
Ports over two fixes from https://github.com/libxmp/libxmp/pull/492:

* The XPK depacker could read uninitialized junk from the end of the data allocation. This behavior seems to be intentional, so I just made it clear these bytes.

* The PowerPacker 2.0 depacker could attempt to skip more than 32 bits in a manner that results in invalid shifts. These files are now rejected. The source of a decompilation project suggests that skip values greater than 32 are impossible anyway.