### PR TITLE
Add cmake rule to disable shared library builds for libmikmod

### DIFF
--- a/libmikmod/CMakeLists.txt
+++ b/libmikmod/CMakeLists.txt
@@ -170,6 +170,10 @@ SET (ENABLE_RPATH 1 CACHE BOOL "Whether to use an rpath when linking" )
 SET (ENABLE_SHARED 1 CACHE BOOL "Whether to build the shared library" )
 SET (ENABLE_STATIC 1 CACHE BOOL "Whether to build the static library" )
 
+IF (NOT ENABLE_STATIC AND NOT ENABLE_SHARED)
+    message(FATAL_ERROR "Both static and shared builds got disabled. You must enable at least one of them.")
+ENDIF()
+
 ### This is to set the RPATH correctly, so when installed
 ### under a prefix the executables will find the libraries.
 ### See:  http://www.cmake.org/Wiki/CMake_RPATH_handling

--- a/libmikmod/CMakeLists.txt
+++ b/libmikmod/CMakeLists.txt
@@ -167,6 +167,7 @@ SET (DISABLE_HQMIXER 0 CACHE BOOL "Exclude support for high quality mixer")
 
 SET (ENABLE_SIMD 0 CACHE BOOL "Use SIMD (AltiVec or SSE2) optimizations (UNSTABLE!!!)")
 SET (ENABLE_RPATH 1 CACHE BOOL "Whether to use an rpath when linking" )
+SET (ENABLE_SHARED 1 CACHE BOOL "Whether to build the shared library" )
 SET (ENABLE_STATIC 1 CACHE BOOL "Whether to build the static library" )
 
 ### This is to set the RPATH correctly, so when installed
@@ -390,12 +391,23 @@ REPLACE_FUNCTIONS_FROMDIR(MIKMOD_LIB_MODULES
 
 SET (LIBMIKMOD_LIBS)
 
-ADD_LIBRARY (mikmod
-    SHARED
-    ${MIKMOD_LIB_MODULES}
+IF (ENABLE_SHARED)
+    ADD_LIBRARY (mikmod
+        SHARED
+        ${MIKMOD_LIB_MODULES}
     )
+    LIST (APPEND LIBMIKMOD_LIBS "mikmod")
 
-LIST (APPEND LIBMIKMOD_LIBS "mikmod")
+    SET_TARGET_PROPERTIES(mikmod
+        PROPERTIES VERSION 3.3.0 SOVERSION 3
+    )
+    IF(WIN32)
+        SET_TARGET_PROPERTIES(mikmod
+            PROPERTIES DEFINE_SYMBOL DLL_EXPORT
+        )
+    ENDIF(WIN32)
+ENDIF()
+
 IF (ENABLE_STATIC)
     ADD_LIBRARY (mikmod-static
         STATIC
@@ -412,15 +424,6 @@ IF (ENABLE_STATIC)
         PROPERTIES CLEAN_DIRECT_OUTPUT 1
     )
 ENDIF (ENABLE_STATIC)
-
-SET_TARGET_PROPERTIES(mikmod
-    PROPERTIES VERSION 3.3.0 SOVERSION 3
-)
-IF(WIN32)
-    SET_TARGET_PROPERTIES(mikmod
-        PROPERTIES DEFINE_SYMBOL DLL_EXPORT
-    )
-ENDIF(WIN32)
 
 IF(DISABLE_HQMIXER)
   SET(NO_HQMIXER 1)


### PR DESCRIPTION
The cmakefile has a rule to enable/disable static builds, which is awesome! However, in some platforms, might not be even possible to generate a shared object (or at least not trivially). For this, it is helpful to have a knob to disable said build.

This PR adds a knob for this, which is enabled by default thus not changing the default behaviour.