### PR TITLE
Fix misc. warnings in MikMod reported by GCC 12.2.1

### DIFF
--- a/mikmod/src/marchive.c
+++ b/mikmod/src/marchive.c
@@ -249,7 +249,7 @@ static BOOL filename2short (const char *l, char *s, int len_s)
 	__dpmi_int (0x21, &r);
 
 	if (r.x.flags & 1) {		/* is carry flag set (-> error) ?  */
-		strncpy (s, l, len_s);
+		strncpy (s, l, len_s - 1);
 		s[len_s - 1] = '\0';
 		return 0;
 	} else {
@@ -266,7 +266,7 @@ static BOOL filename2short (const char *l, char *s, int len_s)
 {
 	int copied = GetShortPathName (l, s, len_s);
 	if (copied == 0 || copied >= len_s) {
-		strncpy (s, l, len_s);
+		strncpy (s, l, len_s - 1);
 		s[len_s - 1] = '\0';
 		return 0;
 	} else
@@ -277,7 +277,7 @@ static BOOL filename2short (const char *l, char *s, int len_s)
 
 static BOOL filename2short (const char *l, char *s, int len_s)
 {
-	strncpy (s, l, len_s);
+	strncpy (s, l, len_s - 1);
 	s[len_s - 1] = '\0';
 	return 1;
 }

--- a/mikmod/src/mconfedit.c
+++ b/mikmod/src/mconfedit.c
@@ -354,6 +354,7 @@ static void get_driver_options(MENTRY *entry, MENTRY *dr_entry)
 /* extract themes for the other menu */
 static void get_themes(MENTRY *entry)
 {
+	char *pos;
 	int i, j, len = 0;
 
 	for (i=0; i<cnt_themes; i++) {
@@ -364,15 +365,17 @@ static void get_themes(MENTRY *entry)
 		free (entry->text);
 	entry->text = (char *) malloc(sizeof(char) * (len + 15));
 	strcpy(entry->text, "T&heme  [%o]");
+	pos = entry->text + strlen(entry->text);
 	for (i=0; i<cnt_themes; i++) {
-		strcat(entry->text, "|");
-		strcat(entry->text,themes[i].color ? "(C) ":"(M) ");
+		strcpy(pos, "|");
+		strcpy(pos + 1, themes[i].color ? "(C) ":"(M) ");
+		pos += 5;
 
-		len = strlen(entry->text);
 		j = strlen (themes[i].name);
 		j = (j>32 ? 32:j);
-		strncat(entry->text, themes[i].name, j);
-		entry->text[len + j] = '\0';
+		memcpy(pos, themes[i].name, j);
+		pos += j;
+		*pos = '\0';
 	}
 }
 

--- a/mikmod/src/mwindow.c
+++ b/mikmod/src/mwindow.c
@@ -603,16 +603,10 @@ void win_init_status(int height)
 void win_status(const char *msg)
 {
 	MWINDOW *win = panel[0];
-	int len;
 
 	if (msg) {
-		len = strlen(msg);
-		if (len > MAXWIDTH)
-			len = MAXWIDTH;
-		strncpy(status_message, msg, len);
-	} else
-		len = strlen(status_message);
-	status_message[len] = '\0';
+		SNPRINTF(status_message, MAXWIDTH, "%s", msg);
+	}
 
 	if (win_quiet)
 		return;
@@ -620,7 +614,8 @@ void win_status(const char *msg)
 		win_attrset(ATTR_STATUS_TEXT);
 		mvaddnstr(win->y + win->height - 1, win->x, status_message,
 				  win->width);
-		win_clrtoeol(win, win->x + len, win->y + win->height - 1);
+		win_clrtoeol(win, win->x + strlen(status_message),
+				  win->y + win->height - 1);
 	}
 }
 


### PR DESCRIPTION
Please CAREFULLY review and test these warning fixes for the MikMod *player*. They seem fine to me and I encountered no issues in the affected parts of the UI.

* display.c:144: buffers were too short to fit the full precision of two `int`s. Doesn't matter in practice, but it costs nothing to make these slightly bigger.
* display.c:392: bounding using `strlen(...) + strlen(...)` confused GCC into somehow thinking the two fields could be long enough to cause truncation. Replacing these with `archivelen`, `filelen`, and moving `filelen` to the right side of the compare seems to fix it.
* display.c:440: signed `int` subtraction of two unsigned bytes can result in a 4-byte long string, potentially causing truncation.
* display.c:968: `tmpfmt` was slightly too short for one of the `sprintf` format strings.
* marchive.c:280: `strncpy` warning should have been suppressed but wasn't.
* mconfedit.c:374: egregious usage of `strcat`/`strncat`.
* mwindow.c:612: bizarre bounding of `strncpy` length on the source string which is better suited to a function that doesn't suck (`snprintf`).

Side note: for affected old MSVCs and MINGWs without the stdio wrappers for `snprintf`, the macro `SNPRINTF` should *probably* have a safety wrapper. Same for `HAVE_VSNPRINTF`, but also the case when `HAVE_VSNPRINTF` isn't defined looks really bad.