### PR TITLE
Fix OOB envelope reads.

### DIFF
--- a/libmikmod/loaders/load_xm.c
+++ b/libmikmod/loaders/load_xm.c
@@ -73,7 +73,8 @@ typedef struct XMINSTHEADER {
 	ULONG ssize;
 } XMINSTHEADER;
 
-#define XMENVCNT (12*2)
+#define XMENVPTS (12)
+#define XMENVCNT (XMENVPTS*2)
 #define XMNOTECNT (8*OCTAVE)
 typedef struct XMPATCHHEADER {
 	UBYTE what[XMNOTECNT];  /*  Sample number for all notes */
@@ -519,10 +520,10 @@ static BOOL LoadInstruments(void)
 				/* we can't trust the envelope point count here, as some
 				   modules have incorrect values (K_OSPACE.XM reports 32 volume
 				   points, for example). */
-				if(pth.volpts>XMENVCNT/2) pth.volpts=XMENVCNT/2;
-				if(pth.panpts>XMENVCNT/2) pth.panpts=XMENVCNT/2;
+				if(pth.volpts>XMENVPTS) pth.volpts=XMENVPTS;
+				if(pth.panpts>XMENVPTS) pth.panpts=XMENVPTS;
 
-				if((_mm_eof(modreader))||(pth.volpts>XMENVCNT/2)||(pth.panpts>XMENVCNT/2)) {
+				if(_mm_eof(modreader)) {
 					MikMod_free(nextwav);nextwav=NULL;
 					MikMod_free(wh);wh=NULL;
 					_mm_errno = MMERR_LOADING_SAMPLEINFO;
@@ -535,7 +536,7 @@ static BOOL LoadInstruments(void)
 
 #if defined __STDC__ || defined _MSC_VER || defined __WATCOMC__ || defined MPW_C
 #define XM_ProcessEnvelope(name) 										\
-				for (u = 0; u < (XMENVCNT >> 1); u++) {					\
+				for (u = 0; u < XMENVPTS; u++) {					\
 					d-> name##env[u].pos = pth. name##env[u << 1];		\
 					d-> name##env[u].val = pth. name##env[(u << 1)+ 1];	\
 				}														\
@@ -548,14 +549,14 @@ static BOOL LoadInstruments(void)
 				d-> name##pts=pth. name##pts;							\
 																		\
 				/* scale envelope */									\
-				for (p=0;p<XMENVCNT/2;p++)								\
+				for (p = 0; p < XMENVPTS; p++)								\
 					d-> name##env[p].val<<=2;							\
 																		\
 				if ((d-> name##flg&EF_ON)&&(d-> name##pts<2))			\
 					d-> name##flg&=~EF_ON
 #else
 #define XM_ProcessEnvelope(name) 											\
-				for (u = 0; u < (XMENVCNT >> 1); u++) {						\
+				for (u = 0; u < XMENVPTS; u++) {						\
 					d-> name/**/env[u].pos = pth. name/**/env[u << 1];		\
 					d-> name/**/env[u].val = pth. name/**/env[(u << 1)+ 1];	\
 				}															\
@@ -569,7 +570,7 @@ static BOOL LoadInstruments(void)
 				d-> name/**/pts=pth. name/**/pts;							\
 																			\
 				/* scale envelope */										\
-				for (p=0;p<XMENVCNT/2;p++)									\
+				for (p = 0; p < XMENVPTS; p++)									\
 					d-> name/**/env[p].val<<=2;								\
 																			\
 				if ((d-> name/**/flg&EF_ON)&&(d-> name/**/pts<2))			\

--- a/libmikmod/playercode/mplayer.c
+++ b/libmikmod/playercode/mplayer.c
@@ -367,6 +367,12 @@ static SWORD StartEnvelope(ENVPR *t,UBYTE flg,UBYTE pts,UBYTE susbeg,UBYTE susen
 		return t->env[0].val;
 	}
 
+	/* Ignore junk loops */
+	if (beg > pts || beg > end)
+		t->flg &= ~EF_LOOP;
+	if (susbeg > pts || susbeg > susend)
+		t->flg &= ~EF_SUSTAIN;
+
 	/* Imago Orpheus sometimes stores an extra initial point in the envelope */
 	if ((t->pts>=2)&&(t->env[0].pos==t->env[1].pos)) {
 		t->a++;


### PR DESCRIPTION
Fixes #70. These bugs were caused by accessing the envelope arrays with loop points that weren't bounded. The second commit just tidies up some mildly messy code and dead checks in the XM loader.