### PR TITLE
Fix use-of-uninitialized of SAMPLE::onfree and SAMPLE::ctx.

### DIFF
--- a/libmikmod/playercode/mwav.c
+++ b/libmikmod/playercode/mwav.c
@@ -187,6 +187,8 @@ static SAMPLE* Sample_LoadRawGeneric_internal(MREADER* reader, ULONG rate, ULONG
 	si->susbegin = 0;
 	si->susend = 0;
 	si->inflags = si->flags = flags;
+	si->onfree = NULL;
+	si->ctx = NULL;
 	if (si->flags & SF_16BITS) {
 		si->length >>= 1;
 		si->loopstart >>= 1;


### PR DESCRIPTION
Should fix #81.