### PR TITLE
Optimize reverb buffer locality

### DIFF
--- a/libmikmod/playercode/virtch.c
+++ b/libmikmod/playercode/virtch.c
@@ -107,6 +107,9 @@ static	UWORD vc_mode;
 static	int RVc1, RVc2, RVc3, RVc4, RVc5, RVc6, RVc7, RVc8;
 static	ULONG RVRindex;
 
+/* Single contiguous block for all reverb buffers */
+static	SLONG *RVbuf_Block=NULL;
+
 /* For Mono or Left Channel */
 static	SLONG *RVbufL1=NULL,*RVbufL2=NULL,*RVbufL3=NULL,*RVbufL4=NULL,
 		      *RVbufL5=NULL,*RVbufL6=NULL,*RVbufL7=NULL,*RVbufL8=NULL;
@@ -645,8 +648,9 @@ static SLONGLONG MixSurroundInterp(const SWORD* srce,SLONG* dest,SLONGLONG idx,S
 
 static void (*MixReverb)(SLONG* srce,NATIVE count);
 
-/* Reverb macros */
-#define COMPUTE_LOC(n) loc##n = RVRindex % RVc##n
+/* Reverb macros -- no modulo in loop */
+#define INIT_LOC(n) loc##n = RVRindex % RVc##n
+#define ADVANCE_LOC(n) if (++loc##n >= RVc##n) loc##n = 0
 #define COMPUTE_LECHO(n) RVbufL##n [loc##n ]=speedup+((ReverbPct*RVbufL##n [loc##n ])>>7)
 #define COMPUTE_RECHO(n) RVbufR##n [loc##n ]=speedup+((ReverbPct*RVbufR##n [loc##n ])>>7)
 
@@ -659,8 +663,8 @@ static void MixReverb_Normal(SLONG* srce,NATIVE count)
 
 	ReverbPct=58+(md_reverb<<2);
 
-	COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-	COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+	INIT_LOC(1); INIT_LOC(2); INIT_LOC(3); INIT_LOC(4);
+	INIT_LOC(5); INIT_LOC(6); INIT_LOC(7); INIT_LOC(8);
 
 	while(count--) {
 		/* Compute the left channel echo buffers */
@@ -672,8 +676,8 @@ static void MixReverb_Normal(SLONG* srce,NATIVE count)
 		/* Prepare to compute actual finalized data */
 		RVRindex++;
 
-		COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-		COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+		ADVANCE_LOC(1); ADVANCE_LOC(2); ADVANCE_LOC(3); ADVANCE_LOC(4);
+		ADVANCE_LOC(5); ADVANCE_LOC(6); ADVANCE_LOC(7); ADVANCE_LOC(8);
 
 		/* left channel */
 		*srce++ +=RVbufL1[loc1]-RVbufL2[loc2]+RVbufL3[loc3]-RVbufL4[loc4]+
@@ -690,8 +694,8 @@ static void MixReverb_Stereo(SLONG* srce,NATIVE count)
 
 	ReverbPct = 92+(md_reverb<<1);
 
-	COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-	COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+	INIT_LOC(1); INIT_LOC(2); INIT_LOC(3); INIT_LOC(4);
+	INIT_LOC(5); INIT_LOC(6); INIT_LOC(7); INIT_LOC(8);
 
 	while(count--) {
 		/* Compute the left channel echo buffers */
@@ -709,8 +713,8 @@ static void MixReverb_Stereo(SLONG* srce,NATIVE count)
 		/* Prepare to compute actual finalized data */
 		RVRindex++;
 
-		COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-		COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+		ADVANCE_LOC(1); ADVANCE_LOC(2); ADVANCE_LOC(3); ADVANCE_LOC(4);
+		ADVANCE_LOC(5); ADVANCE_LOC(6); ADVANCE_LOC(7); ADVANCE_LOC(8);
 
 		/* left channel then right channel */
 		*srce++ +=RVbufL1[loc1]-RVbufL2[loc2]+RVbufL3[loc3]-RVbufL4[loc4]+
@@ -1267,6 +1271,9 @@ int VC1_Init(void)
 
 int VC1_PlayStart(void)
 {
+	int total_L_size;
+	int total_block_size;
+
 	samplesthatfit=TICKLSIZE;
 	if(vc_mode & DMODE_STEREO) samplesthatfit >>= 1;
 	tickleft = 0;
@@ -1280,25 +1287,36 @@ int VC1_PlayStart(void)
 	RVc7 = (7813L * md_mixfreq) / REVERBERATION;
 	RVc8 = (8828L * md_mixfreq) / REVERBERATION;
 
-	if(!(RVbufL1=(SLONG*)MikMod_calloc((RVc1+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL2=(SLONG*)MikMod_calloc((RVc2+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL3=(SLONG*)MikMod_calloc((RVc3+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL4=(SLONG*)MikMod_calloc((RVc4+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL5=(SLONG*)MikMod_calloc((RVc5+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL6=(SLONG*)MikMod_calloc((RVc6+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL7=(SLONG*)MikMod_calloc((RVc7+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL8=(SLONG*)MikMod_calloc((RVc8+1),sizeof(SLONG)))) return 1;
-
-	/* allocate reverb buffers for the right channel if in stereo mode only. */
+	/* Single Contiguous Memory Block: Calculate the total amount of SLONG elements needed for the Left channel */
+	total_L_size = (RVc1+1) + (RVc2+1) + (RVc3+1) + (RVc4+1) + (RVc5+1) + (RVc6+1) + (RVc7+1) + (RVc8+1);
+	total_block_size = total_L_size;
 	if (vc_mode & DMODE_STEREO) {
-		if(!(RVbufR1=(SLONG*)MikMod_calloc((RVc1+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR2=(SLONG*)MikMod_calloc((RVc2+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR3=(SLONG*)MikMod_calloc((RVc3+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR4=(SLONG*)MikMod_calloc((RVc4+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR5=(SLONG*)MikMod_calloc((RVc5+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR6=(SLONG*)MikMod_calloc((RVc6+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR7=(SLONG*)MikMod_calloc((RVc7+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR8=(SLONG*)MikMod_calloc((RVc8+1),sizeof(SLONG)))) return 1;
+		/* Double the allocation size if Stereo is enabled (Right channel) */
+		total_block_size += total_L_size;
+	}
+
+	/* Allocate one single contiguous block in RAM to avoid Heap Fragmentation and Cache Thrashing */
+	if(!(RVbuf_Block=(SLONG*)MikMod_calloc(total_block_size, sizeof(SLONG)))) return 1;
+
+	/* Distribute the pointers linearly within the contiguous block */
+	RVbufL1 = RVbuf_Block;
+	RVbufL2 = RVbufL1 + (RVc1+1);
+	RVbufL3 = RVbufL2 + (RVc2+1);
+	RVbufL4 = RVbufL3 + (RVc3+1);
+	RVbufL5 = RVbufL4 + (RVc4+1);
+	RVbufL6 = RVbufL5 + (RVc5+1);
+	RVbufL7 = RVbufL6 + (RVc6+1);
+	RVbufL8 = RVbufL7 + (RVc7+1);
+
+	if (vc_mode & DMODE_STEREO) {
+		RVbufR1 = RVbufL8 + (RVc8+1); /* Continue linearly from the end of the Left channel */
+		RVbufR2 = RVbufR1 + (RVc1+1);
+		RVbufR3 = RVbufR2 + (RVc2+1);
+		RVbufR4 = RVbufR3 + (RVc3+1);
+		RVbufR5 = RVbufR4 + (RVc4+1);
+		RVbufR6 = RVbufR5 + (RVc5+1);
+		RVbufR7 = RVbufR6 + (RVc6+1);
+		RVbufR8 = RVbufR7 + (RVc7+1);
 	}
 
 	RVRindex = 0;
@@ -1307,23 +1325,11 @@ int VC1_PlayStart(void)
 
 void VC1_PlayStop(void)
 {
-	MikMod_free(RVbufL1);
-	MikMod_free(RVbufL2);
-	MikMod_free(RVbufL3);
-	MikMod_free(RVbufL4);
-	MikMod_free(RVbufL5);
-	MikMod_free(RVbufL6);
-	MikMod_free(RVbufL7);
-	MikMod_free(RVbufL8);
+	/* Free the single contiguous block */
+	MikMod_free(RVbuf_Block);
+	RVbuf_Block = NULL;
+
 	RVbufL1=RVbufL2=RVbufL3=RVbufL4=RVbufL5=RVbufL6=RVbufL7=RVbufL8=NULL;
-	MikMod_free(RVbufR1);
-	MikMod_free(RVbufR2);
-	MikMod_free(RVbufR3);
-	MikMod_free(RVbufR4);
-	MikMod_free(RVbufR5);
-	MikMod_free(RVbufR6);
-	MikMod_free(RVbufR7);
-	MikMod_free(RVbufR8);
 	RVbufR1=RVbufR2=RVbufR3=RVbufR4=RVbufR5=RVbufR6=RVbufR7=RVbufR8=NULL;
 }
 

--- a/libmikmod/playercode/virtch2.c
+++ b/libmikmod/playercode/virtch2.c
@@ -135,6 +135,9 @@ typedef void (*MikMod_callback_t)(unsigned char *data, size_t len);
 static	int RVc1, RVc2, RVc3, RVc4, RVc5, RVc6, RVc7, RVc8;
 static	ULONG RVRindex;
 
+/* Single contiguous block for all reverb buffers */
+static	SLONG *RVbuf_Block=NULL;
+
 /* For Mono or Left Channel */
 static	SLONG *RVbufL1=NULL,*RVbufL2=NULL,*RVbufL3=NULL,*RVbufL4=NULL,
 		      *RVbufL5=NULL,*RVbufL6=NULL,*RVbufL7=NULL,*RVbufL8=NULL;
@@ -598,8 +601,9 @@ static	void(*Mix32to16)(SWORD* dste,const SLONG *srce,NATIVE count);
 static	void(*Mix32to8)(SBYTE* dste,const SLONG *srce,NATIVE count);
 static	void(*MixReverb)(SLONG *srce,NATIVE count);
 
-/* Reverb macros */
-#define COMPUTE_LOC(n) loc##n = RVRindex % RVc##n
+/* Reverb macros -- no modulo in loop */
+#define INIT_LOC(n) loc##n = RVRindex % RVc##n
+#define ADVANCE_LOC(n) if (++loc##n >= RVc##n) loc##n = 0
 #define COMPUTE_LECHO(n) RVbufL##n [loc##n ]=speedup+((ReverbPct*RVbufL##n [loc##n ])>>7)
 #define COMPUTE_RECHO(n) RVbufR##n [loc##n ]=speedup+((ReverbPct*RVbufR##n [loc##n ])>>7)
 
@@ -611,8 +615,8 @@ static void MixReverb_Normal(SLONG *srce,NATIVE count)
 
 	ReverbPct=58+(md_reverb*4);
 
-	COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-	COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+	INIT_LOC(1); INIT_LOC(2); INIT_LOC(3); INIT_LOC(4);
+	INIT_LOC(5); INIT_LOC(6); INIT_LOC(7); INIT_LOC(8);
 
 	while(count--) {
 		/* Compute the left channel echo buffers */
@@ -624,8 +628,8 @@ static void MixReverb_Normal(SLONG *srce,NATIVE count)
 		/* Prepare to compute actual finalized data */
 		RVRindex++;
 
-		COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-		COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+		ADVANCE_LOC(1); ADVANCE_LOC(2); ADVANCE_LOC(3); ADVANCE_LOC(4);
+		ADVANCE_LOC(5); ADVANCE_LOC(6); ADVANCE_LOC(7); ADVANCE_LOC(8);
 
 		/* left channel */
 		*srce++ +=RVbufL1[loc1]-RVbufL2[loc2]+RVbufL3[loc3]-RVbufL4[loc4]+
@@ -641,8 +645,8 @@ static void MixReverb_Stereo(SLONG *srce,NATIVE count)
 
 	ReverbPct=58+(md_reverb*4);
 
-	COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-	COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+	INIT_LOC(1); INIT_LOC(2); INIT_LOC(3); INIT_LOC(4);
+	INIT_LOC(5); INIT_LOC(6); INIT_LOC(7); INIT_LOC(8);
 
 	while(count--) {
 		/* Compute the left channel echo buffers */
@@ -660,8 +664,8 @@ static void MixReverb_Stereo(SLONG *srce,NATIVE count)
 		/* Prepare to compute actual finalized data */
 		RVRindex++;
 
-		COMPUTE_LOC(1); COMPUTE_LOC(2); COMPUTE_LOC(3); COMPUTE_LOC(4);
-		COMPUTE_LOC(5); COMPUTE_LOC(6); COMPUTE_LOC(7); COMPUTE_LOC(8);
+		ADVANCE_LOC(1); ADVANCE_LOC(2); ADVANCE_LOC(3); ADVANCE_LOC(4);
+		ADVANCE_LOC(5); ADVANCE_LOC(6); ADVANCE_LOC(7); ADVANCE_LOC(8);
 
 		/* left channel */
 		*srce++ +=RVbufL1[loc1]-RVbufL2[loc2]+RVbufL3[loc3]-RVbufL4[loc4]+
@@ -1276,6 +1280,9 @@ int VC2_Init(void)
 
 int VC2_PlayStart(void)
 {
+	int total_L_size;
+	int total_block_size;
+
 	md_mode|=DMODE_INTERP;
 
 	samplesthatfit = TICKLSIZE;
@@ -1291,25 +1298,37 @@ int VC2_PlayStart(void)
 	RVc7 = (7813L * md_mixfreq) / (REVERBERATION * 10);
 	RVc8 = (8828L * md_mixfreq) / (REVERBERATION * 10);
 
-	if(!(RVbufL1=(SLONG*)MikMod_calloc((RVc1+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL2=(SLONG*)MikMod_calloc((RVc2+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL3=(SLONG*)MikMod_calloc((RVc3+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL4=(SLONG*)MikMod_calloc((RVc4+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL5=(SLONG*)MikMod_calloc((RVc5+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL6=(SLONG*)MikMod_calloc((RVc6+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL7=(SLONG*)MikMod_calloc((RVc7+1),sizeof(SLONG)))) return 1;
-	if(!(RVbufL8=(SLONG*)MikMod_calloc((RVc8+1),sizeof(SLONG)))) return 1;
+	/* Single Contiguous Memory Block: Calculate the total amount of SLONG elements needed for the Left channel */
+	total_L_size = (RVc1+1) + (RVc2+1) + (RVc3+1) + (RVc4+1) + (RVc5+1) + (RVc6+1) + (RVc7+1) + (RVc8+1);
+	total_block_size = total_L_size;
+	if (vc_mode & DMODE_STEREO) {
+		/* Double the allocation size if Stereo is enabled (Right channel) */
+		total_block_size += total_L_size;
+	}
+
+	/* Allocate one single contiguous block in RAM to avoid Heap Fragmentation and Cache Thrashing */
+	if(!(RVbuf_Block=(SLONG*)MikMod_calloc(total_block_size, sizeof(SLONG)))) return 1;
+
+	/* Distribute the pointers linearly within the contiguous block */
+	RVbufL1 = RVbuf_Block;
+	RVbufL2 = RVbufL1 + (RVc1+1);
+	RVbufL3 = RVbufL2 + (RVc2+1);
+	RVbufL4 = RVbufL3 + (RVc3+1);
+	RVbufL5 = RVbufL4 + (RVc4+1);
+	RVbufL6 = RVbufL5 + (RVc5+1);
+	RVbufL7 = RVbufL6 + (RVc6+1);
+	RVbufL8 = RVbufL7 + (RVc7+1);
 
 	/* allocate reverb buffers for the right channel if in stereo mode only. */
 	if (vc_mode & DMODE_STEREO) {
-		if(!(RVbufR1=(SLONG*)MikMod_calloc((RVc1+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR2=(SLONG*)MikMod_calloc((RVc2+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR3=(SLONG*)MikMod_calloc((RVc3+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR4=(SLONG*)MikMod_calloc((RVc4+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR5=(SLONG*)MikMod_calloc((RVc5+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR6=(SLONG*)MikMod_calloc((RVc6+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR7=(SLONG*)MikMod_calloc((RVc7+1),sizeof(SLONG)))) return 1;
-		if(!(RVbufR8=(SLONG*)MikMod_calloc((RVc8+1),sizeof(SLONG)))) return 1;
+		RVbufR1 = RVbufL8 + (RVc8+1); /* Continue linearly from the end of the Left channel */
+		RVbufR2 = RVbufR1 + (RVc1+1);
+		RVbufR3 = RVbufR2 + (RVc2+1);
+		RVbufR4 = RVbufR3 + (RVc3+1);
+		RVbufR5 = RVbufR4 + (RVc4+1);
+		RVbufR6 = RVbufR5 + (RVc5+1);
+		RVbufR7 = RVbufR6 + (RVc6+1);
+		RVbufR8 = RVbufR7 + (RVc7+1);
 	}
 
 	RVRindex = 0;
@@ -1318,22 +1337,9 @@ int VC2_PlayStart(void)
 
 void VC2_PlayStop(void)
 {
-	MikMod_free(RVbufL1);
-	MikMod_free(RVbufL2);
-	MikMod_free(RVbufL3);
-	MikMod_free(RVbufL4);
-	MikMod_free(RVbufL5);
-	MikMod_free(RVbufL6);
-	MikMod_free(RVbufL7);
-	MikMod_free(RVbufL8);
-	MikMod_free(RVbufR1);
-	MikMod_free(RVbufR2);
-	MikMod_free(RVbufR3);
-	MikMod_free(RVbufR4);
-	MikMod_free(RVbufR5);
-	MikMod_free(RVbufR6);
-	MikMod_free(RVbufR7);
-	MikMod_free(RVbufR8);
+	/* Free the single contiguous block */
+	MikMod_free(RVbuf_Block);
+	RVbuf_Block = NULL;
 
 	RVbufL1=RVbufL2=RVbufL3=RVbufL4=RVbufL5=RVbufL6=RVbufL7=RVbufL8=NULL;
 	RVbufR1=RVbufR2=RVbufR3=RVbufR4=RVbufR5=RVbufR6=RVbufR7=RVbufR8=NULL;


### PR DESCRIPTION
## Summary

Hi MikMod maintainers,

My collaborator @thomasstaheli and I recently studied a MikMod-based audio pipeline as part of our High-Performance Computing course at HEIG-VD in Yverdon, Switzerland. During this work, we profiled the reverb mixing code and identified `MixReverb_Stereo` as a noticeable hotspot in the audio path.

This pull request proposes two small optimizations for the reverb mixer:

1. improving the memory layout of the reverb buffers;
2. reducing the arithmetic cost of circular buffer indexing.

The goal is to improve performance in a frequently executed DSP path without changing the reverb algorithm or the intended audio output.

## Motivation

The stereo reverb mixer repeatedly accesses 16 circular buffers:

- `RVbufL1` to `RVbufL8` for the left channel;
- `RVbufR1` to `RVbufR8` for the right channel.

In the original implementation, these buffers are allocated separately. This can scatter them across the heap and reduce spatial locality. Since the reverb loop reads and writes these buffers very frequently, a more cache-friendly layout can help reduce memory stalls.

The inner loop also performs repeated modulo operations for circular indexing. These modulo operations may compile to integer divisions, which are relatively expensive compared to simple increments and comparisons.

## Changes

### 1. Contiguous reverb buffer allocation

The separate reverb buffer allocations are replaced with a single contiguous allocation. The existing `RVbufL*` and `RVbufR*` pointers are then assigned linearly inside this block.

This keeps the rest of the code structure mostly unchanged, while improving spatial locality and reducing heap fragmentation.

### 2. Strength reduction for circular indexing

The repeated modulo-based index updates in the inner reverb loop are replaced with conditional increments:

```c
if (++loc >= RVc)
    loc = 0;
````

The modulo is only needed for initialization. During the loop, the index advances with cheaper operations: increment, comparison, and conditional reset.

## Performance notes

This change was motivated by profiling in a downstream project using MikMod-based audio mixing. In that environment, `MixReverb_Stereo` was one of the relevant audio hotspots.

Using Linux `perf`, we observed the following self CPU cost for the targeted function:

* baseline run 1: 5.38%;
* baseline run 2: 5.69%;
* optimized run: 4.33%.

Using the average of the two baseline runs, this corresponds to a relative reduction of approximately 21.8% for `MixReverb_Stereo` in that workload.

These numbers are workload- and platform-dependent, so they should be interpreted as an indication rather than a universal benchmark. The main goal of this PR is to make the reverb buffer access pattern more cache-friendly and reduce unnecessary arithmetic in a hot loop.

## Compatibility

The reverb algorithm is not intentionally changed. The existing buffer pointer interface is preserved, and the optimization only changes how the buffers are allocated and how circular indices are advanced internally.

Please let us know if you would prefer the patch to be split differently, rebased, or adjusted to better match the coding style of the project.

Best regards,
@Ali-Z0 and @thomasstaheli

