### PR TITLE
Add bounding checks for DSMI AMF channel remap table.

### DIFF
--- a/libmikmod/loaders/load_amf.c
+++ b/libmikmod/loaders/load_amf.c
@@ -423,8 +423,15 @@ static BOOL AMF_Load(BOOL curious)
 	if(mh->version>=11) {
 		memset(mh->panpos,0,32);
 		_mm_read_SBYTES(mh->panpos,(mh->version>=13)?32:16,modreader);
-	} else if(mh->version>=9)
+	} else if(mh->version>=9) {
 		_mm_read_UBYTES(channel_remap,16,modreader);
+		for(t = 0; t < 16 && t < mh->numchannels; t++) {
+			if(channel_remap[t] >= mh->numchannels) {
+				_mm_errno=MMERR_NOT_A_MODULE;
+				return 0;
+			}
+		}
+	}
 
 	if (mh->version>=13) {
 		mh->songbpm=_mm_read_UBYTE(modreader);


### PR DESCRIPTION
The indices in this table corresponding to real channels should also point to real channel numbers.

Verified that Test6.amf, reborning.amf, and the tribal zone.amf still load after this fix. This feature is only used by format versions 0.9 and 1.0.